### PR TITLE
prebuild lua library if needed

### DIFF
--- a/tools/imgui_test/CMakeLists.txt
+++ b/tools/imgui_test/CMakeLists.txt
@@ -40,8 +40,19 @@ set(BG3SE_LUA_SOURCES
     ${BG3SE_ROOT}/src/lua/lua_imgui.c
 )
 
-# Pre-built Lua library
+# Lua Library
 set(LUA_LIBRARY ${BG3SE_ROOT}/lib/lua/liblua-universal.a)
+if(NOT EXISTS "${LUA_LIBRARY}")
+    message(STATUS "liblua-universal.a not found, building...")
+    execute_process(
+        COMMAND bash ${BG3SE_ROOT}/lib/lua/build_universal.sh
+        WORKING_DIRECTORY ${BG3SE_ROOT}/lib/lua
+        RESULT_VARIABLE LUA_BUILD_RESULT
+    )
+    if(NOT LUA_BUILD_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to build Lua library (exit code: ${LUA_BUILD_RESULT})")
+    endif()
+endif()
 
 # Create executable
 add_executable(imgui_test


### PR DESCRIPTION
Following the instructions listed in the 'Build & Install' section of the README, the build fails to compile, owing to the following error:

```
*** No rule to make target `/Users/nathan/repositories/bg3se-macos/tools/imgui_test/../../lib/lua/liblua-universal.a', needed by `bin/imgui_test'.  Stop.
make[1]: *** [tools/imgui_test/CMakeFiles/imgui_test.dir/all] Error 2
```

There are two viable solutions:
- check if the library `.a` file is present, and if it isnt, run `universal_build.sh` as part of the cmake script
- add `universal_build.sh` to the README instructions

I've taken the liberty of implementing option 1 here, but feel free to push back - happy to go down route # 2 if that's preferable