### PR TITLE
fix: gate staticdata/template Dobby hooks on exact version match (#78 regression)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ add_library(bg3se SHARED
     src/core/safe_memory.c
     src/core/crashlog.c
     src/core/version_detect.c
+    src/core/offset_table.c
     src/core/mach_exception.c
     src/core/mach_exc_stubs/mach_excServer.c
     src/lua/lua_ext.c

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -1,0 +1,123 @@
+# Porting BG3SE-macOS to a new game version
+
+When Larian patches Baldur's Gate 3, the macOS Script Extender breaks because the
+game's functions and global variables move to new addresses. This guide + the
+`tools/port_offsets.py` tool turn that re-port from a multi-hour reverse‑engineering
+session into, usually, **run a script and paste the output**.
+
+## Why this is easy on macOS (and hard on Windows)
+
+The macOS BG3 binary **ships with its symbol table** — ~725,000 named symbols.
+So almost every address the extender needs can be found by name with `nm`, no
+Ghidra required. (Norbyte's Windows extender needs heavy pattern‑scanning because
+the Windows binary is stripped.)
+
+There are two kinds of address, and only one kind changes per patch:
+
+| Kind | Example | Changes per patch? | How to find |
+|------|---------|--------------------|-------------|
+| **Absolute address** | `SpellPrototype::Init` entry point; `RPGStats::m_ptr` slot | **Yes** | `nm` by symbol, or a uniform `__DATA` shift |
+| **Struct field offset** | EocServer → EntityWorld is at `+0x288` | No (until a class is restructured) | One‑time Ghidra/runtime; carried forward |
+
+`tools/offset_manifest.json` lists every address in both categories with its
+symbol and resolution method. It is the source of truth — the recipe.
+
+## TL;DR — re-port to your installed version
+
+```bash
+# 1. See what resolves and what (if anything) needs attention:
+python3 tools/port_offsets.py resolve
+
+# 2. Print copy-pasteable C for src/core/offset_table.c:
+python3 tools/port_offsets.py resolve --emit
+
+# 3. Paste the generated struct entry into g_offset_table[] and the remap
+#    rows into g_fn_remap_<yourversion>[] (add that array + a branch in
+#    offset_table_remap_fn for the new version string), then:
+cd build && cmake --build .
+
+# 4. Launch, load a save, and run the regression suite:
+#    !test        (in the SE console)  -> expect 109/109
+#    !test_ingame
+```
+
+The tool auto-detects your version from the app's `Info.plist`. Override with
+`--binary PATH` or `--version X.Y.Z` if needed.
+
+## Verifying the tool against a known-good version
+
+```bash
+python3 tools/port_offsets.py verify
+```
+
+This resolves every address against your binary and **diffs against the values
+already in `offset_table.c`**. On the version the table was built for it prints
+`✓ all N fields + M remap entries match`. That's the proof the automation
+reproduces hand-done work before you trust it on a new version.
+
+## Reading the output / fixing flags
+
+The resolver classifies every item:
+
+- `[INFO] __DATA shift derived ...` — the uniform shift for non-exported globals
+  (e.g. `RPGStats::m_ptr`), computed from the `data_shift_anchor`. Sanity-check it
+  looks like a small, plausible delta.
+- `[WARN] ... AMBIGUOUS` — the symbol matched more than one address (e.g. const
+  vs non-const overload). The tool takes the lowest; **make the manifest `symbol`
+  more specific** (full signature) so it's unique, then re-run.
+- `[ERROR] ... symbol not found` — the function was renamed/inlined, or the
+  signature drifted. Open the binary's symbols (`nm BINARY | c++filt | grep Name`)
+  and update the manifest `symbol`. If it's genuinely gone, that feature needs
+  rework.
+- `[ERROR] constant ... CHANGED` — an address we assumed was stable moved. Move
+  that entry from `constant_functions` to `remap_functions`.
+- `[WARN] exported_data ... shift != __DATA shift` — that global lives in a
+  segment that shifted differently. Resolve it by its own symbol (it already is)
+  and don't rely on the uniform shift for it.
+
+Anything not flagged resolved cleanly.
+
+## When you DO need Ghidra (struct offsets)
+
+`struct_offsets` in the manifest are field offsets *inside* objects (e.g.
+`EntityWorld -> StorageContainer` at `+0x2d0`). They're stable across minor
+patches and the tool just carries them. They only change if Larian restructures
+a class — symptoms are a crash *inside* a game function after the entry address
+is already correct, or a structural read returning garbage. To re-find one:
+
+- Each entry has a `verify_via` / `where` pointing at how it was originally found
+  (often a one-line disassembly check, e.g. `EocServer::StartUp` does
+  `ldr xN,[this,#0x288]`). `otool -tV` the named function and read the offset.
+- Or probe at runtime with `Ext.Debug.ProbeStruct` / `ReadPtr` against a live
+  object (see `agent_docs/development.md`).
+
+Update the `value` in the manifest and the matching `#define` in the code.
+
+## Adding a brand-new address to the recipe
+
+If you wire a new game function/global into the extender, add it to the manifest
+so future ports resolve it automatically:
+
+- A called game function → `remap_functions` (or `offset_table_functions` if it
+  has a dedicated `VersionOffsets` field). Give the exact demangled `symbol` and
+  its current-version `baseline` address.
+- A non-exported singleton pointer → `data_singletons` with its `baseline` offset.
+- A field offset inside an object → `struct_offsets`.
+
+Find the exact symbol string with:
+
+```bash
+nm "$BG3_BINARY" | c++filt | grep "YourFunctionName"
+```
+
+Use whatever `c++filt` prints, verbatim, as the manifest `symbol` (whitespace is
+normalized during matching).
+
+## How the remap table works (background)
+
+Many subsystems hold a hardcoded *baseline* (6995620) game-function address and
+call it as a function pointer. `offset_table_remap_fn(addr)` (in `offset_table.c`)
+returns the correct address for the running version, or **0 if it isn't in the
+remap table — in which case the caller skips that feature instead of jumping to a
+stale address and crashing.** So even an un-ported function degrades gracefully.
+The tool generates the `g_fn_remap_<version>[]` rows for you.

--- a/src/audio/audio_manager.c
+++ b/src/audio/audio_manager.c
@@ -15,6 +15,7 @@
 #include "audio_manager.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/offset_table.h"
 #include "../strings/fixed_string.h"
 #include <stdlib.h>
 #include <string.h>
@@ -24,8 +25,9 @@
 // Constants and Offsets
 // ============================================================================
 
-// ResourceManager::m_ptr (shared with resource_manager.c)
-#define OFFSET_RESOURCEMANAGER_PTR   0x08a8f070
+// ResourceManager::m_ptr — sourced from offset_table at runtime
+// Fallback value kept for reference: 0x08a8f070 (4.1.1.6995620)
+#define OFFSET_RESOURCEMANAGER_PTR_FALLBACK  0x08a8f070
 
 // SoundManager offset within ResourceManager (needs runtime discovery)
 // Placeholder - probe ResourceManager struct to find actual offset
@@ -116,15 +118,24 @@ bool audio_manager_init(void *main_binary_base) {
     }
 
     g_audio.main_binary_base = main_binary_base;
-    g_audio.resource_manager_ptr = (void **)((uintptr_t)main_binary_base + OFFSET_RESOURCEMANAGER_PTR);
 
-    // Resolve ls::STDString constructor for PlayExternalSound path parameter
-    g_audio.stdstring_ctor = (STDStringCtorFn)((uintptr_t)main_binary_base + OFFSET_STDSTRING_CTOR);
+    const VersionOffsets *off = offset_table_get();
+    if (off && off->resource_mgr_ptr) {
+        g_audio.resource_manager_ptr = (void **)offset_table_resolve(off->resource_mgr_ptr);
+    } else {
+        g_audio.resource_manager_ptr = (void **)((uintptr_t)main_binary_base + OFFSET_RESOURCEMANAGER_PTR_FALLBACK);
+    }
+
+    // Resolve ls::STDString constructor (remap the hardcoded 6995620 address).
+    // NULL if no verified address -> PlayExternalSound's string path is skipped.
+    uint64_t stdstr_ghidra = offset_table_remap_fn(0x100000000ULL + OFFSET_STDSTRING_CTOR);
+    g_audio.stdstring_ctor = stdstr_ghidra
+        ? (STDStringCtorFn)((uintptr_t)main_binary_base + (stdstr_ghidra - 0x100000000ULL))
+        : NULL;
 
     log_message("[Audio] Audio manager initialized");
     log_message("[Audio]   Base: %p", main_binary_base);
-    log_message("[Audio]   ResourceManager::m_ptr at offset 0x%x -> %p",
-                OFFSET_RESOURCEMANAGER_PTR, (void *)g_audio.resource_manager_ptr);
+    log_message("[Audio]   ResourceManager::m_ptr -> %p", (void *)g_audio.resource_manager_ptr);
     log_message("[Audio]   STDString ctor: %p", (void *)g_audio.stdstring_ctor);
 
     g_audio.initialized = true;

--- a/src/core/offset_table.c
+++ b/src/core/offset_table.c
@@ -1,0 +1,237 @@
+/**
+ * offset_table.c - Per-version memory offset table for BG3SE-macOS
+ *
+ * To add support for a new BG3 version, DON'T do it by hand — run the resolver:
+ *     python3 tools/port_offsets.py resolve --emit
+ * and paste its output (the struct entry + the g_fn_remap_<ver>[] rows) here.
+ * The recipe of every address is tools/offset_manifest.json; see docs/PORTING.md.
+ * Validate any change with:  python3 tools/port_offsets.py verify
+ *
+ * Manual fallback (if a symbol can't be resolved):
+ *   - Singleton offsets: `nm` the binary, or runtime probe (Ext.Debug.ReadPtr).
+ *   - Function offsets: `nm`/Ghidra. Fields left 0 = "unknown" -> callers skip
+ *     that feature gracefully rather than crash.
+ *
+ * All offsets are (Ghidra address - 0x100000000), i.e. offset from binary load base.
+ */
+
+#include "offset_table.h"
+#include "version_detect.h"
+#include "logging.h"
+
+#include <string.h>
+
+// ============================================================================
+// Version Table
+// ============================================================================
+
+static const VersionOffsets g_offset_table[] = {
+
+    /* ------------------------------------------------------------------
+     * 4.1.1.6995620 — original verified version
+     * All offsets discovered via Ghidra analysis (Dec 2025).
+     * ------------------------------------------------------------------ */
+    {
+        .version                 = "4.1.1.6995620",
+
+        /* Singleton pointer globals */
+        .eocserver_ptr           = 0x0898e8b8,  // esv::EocServer::m_ptr
+        .eocclient_ptr           = 0x0898c968,  // ecl::EocClient::m_ptr
+        .spell_proto_mgr_ptr     = 0x089bac80,  // SpellPrototypeManager::m_ptr
+        .rpgstats_ptr            = 0x089c5730,  // RPGStats::m_ptr
+        .resource_mgr_ptr        = 0x08a8f070,  // ResourceManager::m_ptr
+        .level_mgr_ptr           = 0x08a3be40,  // LevelManager::m_ptr
+        .global_template_mgr_ptr = 0x08a88508,  // ls::GlobalTemplateManager::m_ptr
+        .cache_template_mgr_ptr  = 0x08a309a8,  // CacheTemplateManager::m_ptr
+        .level_cache_mgr_ptr     = 0x08a735d8,  // Level::s_CacheTemplateManager
+        .staticdata_mstate_ptr   = 0x083c4a68,  // ImmutableDataHeadmaster::m_State
+        .gst_ptr                 = 0x08aeccd8,  // ls::gGlobalStringTable
+
+        /* Function offsets */
+        .fn_feat_getfeats        = 0x01b752b4,  // FeatManager::GetFeats
+        .fn_getallfeats          = 0x0120b3e8,  // GetAllFeats
+        .fn_get_background       = 0x02994834,  // Get<eoc::BackgroundManager>
+        .fn_get_origin           = 0x0341c42c,  // Get<eoc::OriginManager>
+        .fn_get_class            = 0x0262f184,  // Get<eoc::ClassDescriptions>
+        .fn_get_progression      = 0x03697f0c,  // Get<eoc::ProgressionManager>
+        .fn_get_actionresource   = 0x011a4494,  // Get<eoc::ActionResourceTypes>
+        .fn_get_template_raw     = 0x05f96304,  // GlobalTemplateManager::GetTemplateRaw
+        .fn_cache_template       = 0x05d31ce4,  // CacheTemplateManagerBase::CacheTemplate
+
+        /* Entity system */
+        .fn_try_get_uuid_mapping = 0x010dc924,  // TryGetSingleton<uuid::ToHandleMappingComponent>
+        .fn_storage_tryget       = 0x0636b27c,  // ecs::EntityStorageContainer::TryGet
+        .fn_spell_proto_init     = 0x01f72754,  // eoc::SpellPrototype::Init
+        .component_data_shift    = 0,           // baseline: TypeId addresses unshifted
+    },
+
+    /* ------------------------------------------------------------------
+     * 4.1.1.7209685 — in use as of June 2026
+     *
+     * The entire __DATA segment shifted by a uniform +0x8000 relative to
+     * 6995620. This was established by:
+     *   - Export-trie diff: ls::TypeId<eoc::FeatManager,...>::m_TypeIndex
+     *     moved 0x1088efd00 -> 0x1088f7d00 (exactly +0x8000).
+     *   - otool ADRP/LDR reference-frequency scan: every old singleton
+     *     offset + 0x8000 lands on a hot (heavily-referenced) __DATA slot.
+     *   - Runtime structural validation against a loaded session:
+     *       rpgstats(+0xd4)=16994 objects, fixedstrings pool at +0x348;
+     *       ResourceManager banks valid at +0x28/+0x30;
+     *       StaticData TypeContext traversal yields 121 named managers
+     *       (FeatManager, RaceManager, BackgroundManager, ... ClassDescriptions).
+     * So every singleton below is simply (6995620 value + 0x8000).
+     *
+     * Function offsets live in __TEXT, which did NOT shift uniformly (the
+     * three template accessors moved -0x105E8, the feat funcs -0x1BAA0, the
+     * Get<T> accessors ~-0x1A7A8), so they were resolved individually by
+     * symbol-table lookup (nm) rather than a constant shift. The macOS
+     * binary is essentially fully symbolized (765k local+global symbols),
+     * so each function below is the address of its named symbol.
+     * ------------------------------------------------------------------ */
+    {
+        .version                 = "4.1.1.7209685",
+
+        /* Singleton pointer globals — uniform +0x8000 vs 6995620 (validated) */
+        .eocserver_ptr           = 0x089968b8,  // 0x0898e8b8 + 0x8000
+        .eocclient_ptr           = 0x08994968,  // 0x0898c968 + 0x8000
+        .spell_proto_mgr_ptr     = 0x089c2c80,  // 0x089bac80 + 0x8000
+        .rpgstats_ptr            = 0x089cd730,  // 0x089c5730 + 0x8000 (count=16994)
+        .resource_mgr_ptr        = 0x08a97070,  // 0x08a8f070 + 0x8000 (banks valid)
+        .level_mgr_ptr           = 0x08a43e40,  // 0x08a3be40 + 0x8000
+        .global_template_mgr_ptr = 0x08a90508,  // 0x08a88508 + 0x8000
+        .cache_template_mgr_ptr  = 0x08a389a8,  // 0x08a309a8 + 0x8000
+        .level_cache_mgr_ptr     = 0x08a7b5d8,  // 0x08a735d8 + 0x8000
+        .staticdata_mstate_ptr   = 0x083cca68,  // 0x083c4a68 + 0x8000 (121 managers)
+        .gst_ptr                 = 0x08af4cd8,  // 0x08aeccd8 + 0x8000 (val=GST ptr, validated)
+
+        /* Function offsets (__TEXT) — resolved by nm symbol lookup on the
+         * 7209685 binary; non-uniform shift, see note above. */
+        .fn_feat_getfeats        = 0x01b59814,  // eoc::FeatManager::GetFeats() const
+        .fn_getallfeats          = 0x011ef948,  // eoc::character_creation::GetAllFeats(Environment const&)
+        .fn_get_background       = 0x0297a068,  // ImmutableDataHeadmaster::Get<eoc::BackgroundManager>() const
+        .fn_get_origin           = 0x03401c84,  // ImmutableDataHeadmaster::Get<eoc::OriginManager>() const
+        .fn_get_class            = 0x02614874,  // ImmutableDataHeadmaster::Get<eoc::ClassDescriptions>() const
+        .fn_get_progression      = 0x0367d764,  // ImmutableDataHeadmaster::Get<eoc::ProgressionManager>() const
+        .fn_get_actionresource   = 0x011889f4,  // ImmutableDataHeadmaster::Get<eoc::ActionResourceTypes>() const
+        .fn_get_template_raw     = 0x05f85d1c,  // ls::GlobalTemplateManager::GetTemplateRaw(FixedString const&) const
+        .fn_cache_template       = 0x05d216fc,  // ls::CacheTemplateManagerBase::CacheTemplate(...)
+
+        /* Entity system (verified end-to-end).
+         * fn_try_get_uuid_mapping: ecs::legacy::Helper::TryGetSingleton<
+         *   uuid::ToHandleMappingComponent const> (symbol-verified, old-0x1baa0).
+         * The earlier crash was NOT this offset — it was read_eocserver_from_global
+         * reading a stale EocServer address, yielding a garbage EntityWorld.
+         * With the EocServer source fixed (offset table eocserver_ptr) the
+         * EntityWorld at EocServer+0x288 is valid (probe-confirmed: 0xc8bb74000
+         * with sane sub-structure), and EocServer::StartUp's `ldr x20,[x19,#0x288]`
+         * confirms +0x288 is unchanged for this version.
+         * component_data_shift: uniform +0x8000 __DATA shift. */
+        .fn_try_get_uuid_mapping = 0x010c0e84,
+        .fn_storage_tryget       = 0x0635ac94,  // ecs::EntityStorageContainer::TryGet (old 0x0636b27c - 0x105E8)
+        .fn_spell_proto_init     = 0x01f56cb4,  // eoc::SpellPrototype::Init (old 0x01f72754 - 0x1baa0)
+        .component_data_shift    = 0x8000,
+    },
+
+};
+
+#define NUM_VERSIONS (sizeof(g_offset_table) / sizeof(g_offset_table[0]))
+
+// ============================================================================
+// Per-version function-address remap
+// ============================================================================
+//
+// Many subsystems still hold hardcoded 6995620 game-function addresses (called
+// as function pointers). On a shifted version these point at the wrong function
+// and SIGBUS when invoked. Rather than thread ~20 fields through VersionOffsets,
+// callers wrap their hardcoded 6995620 Ghidra address with offset_table_remap_fn()
+// which returns the correct address for the active version. All values are full
+// Ghidra addresses (>= 0x100000000); all new values are symbol-verified.
+
+typedef struct { uint64_t from6995620; uint64_t to; } FnRemap;
+
+static const FnRemap g_fn_remap_7209685[] = {
+    { 0x1064b9ebc, 0x1064a8a74 },  // ls::FixedString::Create(char const*, int)   (ABI verified)
+    { 0x1060cc608, 0x1060bc020 },  // ls::ResourceContainer::GetResource
+    { 0x105783a38, 0x10577399c },  // ExecuteStatsFunctor (main dispatcher)
+    { 0x105787918, 0x10577787c },  // esv::functor::ExecuteStatsFunctors<AttackTarget>
+    { 0x105787c6c, 0x105777bd0 },  //   <AttackPosition>
+    { 0x10578975c, 0x1057796c0 },  //   <Move>
+    { 0x10578a918, 0x10577a87c },  //   <Target>
+    { 0x10578e4d8, 0x10577e43c },  //   <NearbyAttacked>
+    { 0x10578fba8, 0x10577fb0c },  //   <NearbyAttacking>
+    { 0x105790a28, 0x10578098c },  //   <Equip>
+    { 0x105792a90, 0x1057829f4 },  //   <Source>
+    { 0x1057965e4, 0x105786548 },  //   <Interrupt>
+    { 0x106534d54, 0x10652390c },  // ls::TranslatedStringRepository::TryGet
+    { 0x106535148, 0x106523d00 },  // ls::TranslatedStringRepository::Get
+    { 0x106532590, 0x106521148 },  // ls::TranslatedStringRepository::AddTranslatedString
+    { 0x1063d5998, 0x1063c4550 },  // net::MessageFactory::GetFreeMessage
+    { 0x10651fb60, 0x10650e718 },  // ls::STDString::STDString(char const*)  (audio PlayExternalSound)
+    // Note: bik::BinkManager::LoadVideo (0x10390b6cc) is unchanged across versions.
+    // GetComponent<T> template addresses are intentionally NOT remapped: that path
+    // is dead on macOS (templates inlined), so it returns 0 here and is skipped.
+};
+
+// ============================================================================
+// State
+// ============================================================================
+
+static const VersionOffsets *g_active = NULL;
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+void offset_table_init(void) {
+    const char *version = version_detect_get_version();
+    if (!version) {
+        log_message("[OffsetTable] Version not detected — all address-dependent features disabled");
+        return;
+    }
+
+    for (int i = 0; i < (int)NUM_VERSIONS; i++) {
+        if (strcmp(g_offset_table[i].version, version) == 0) {
+            g_active = &g_offset_table[i];
+            log_message("[OffsetTable] Loaded offsets for %s", version);
+            return;
+        }
+    }
+
+    log_message("[OffsetTable] Version %s not in table — running in degraded mode. "
+                "Add a new entry to src/core/offset_table.c to enable full features.",
+                version);
+}
+
+const VersionOffsets *offset_table_get(void) {
+    return g_active;
+}
+
+void *offset_table_resolve(uintptr_t offset) {
+    if (!offset) return NULL;
+    void *base = version_detect_get_binary_base();
+    if (!base) return NULL;
+    return (void *)((uintptr_t)base + offset);
+}
+
+void *offset_table_fn(uintptr_t offset) {
+    return offset_table_resolve(offset);
+}
+
+uint64_t offset_table_remap_fn(uint64_t ghidra_addr_6995620) {
+    // Baseline / unknown version: use the caller's address unchanged.
+    if (!g_active || g_active == &g_offset_table[0]) {
+        return ghidra_addr_6995620;
+    }
+    // 7209685 (and any future shifted version with a remap table): look up the
+    // verified equivalent. Anything NOT in the table is returned as 0 so the
+    // caller disables that feature instead of jumping to a stale address.
+    if (strcmp(g_active->version, "4.1.1.7209685") == 0) {
+        for (size_t i = 0; i < sizeof(g_fn_remap_7209685) / sizeof(g_fn_remap_7209685[0]); i++) {
+            if (g_fn_remap_7209685[i].from6995620 == ghidra_addr_6995620) {
+                return g_fn_remap_7209685[i].to;
+            }
+        }
+        return 0;  // unmapped on a shifted version -> disabled (graceful)
+    }
+    return ghidra_addr_6995620;
+}

--- a/src/core/offset_table.h
+++ b/src/core/offset_table.h
@@ -1,0 +1,119 @@
+/**
+ * offset_table.h - Per-version memory offset table for BG3SE-macOS
+ *
+ * All address-dependent features (stats, entity, staticdata, templates, audio,
+ * level) derive their runtime pointers from this table. Adding a new BG3 version
+ * means adding one row here; no other files need editing for the address changes.
+ *
+ * Addressing convention:
+ *   All fields are stored as offsets from the binary load base (i.e. the Ghidra
+ *   address minus 0x100000000). Runtime address = binary_base + field_value.
+ *   A field value of 0 means "unknown for this version — skip gracefully".
+ */
+
+#ifndef OFFSET_TABLE_H
+#define OFFSET_TABLE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    const char *version;                 // e.g. "4.1.1.6995620"
+
+    /* ------------------------------------------------------------------ */
+    /* Data-segment singleton pointer globals                              */
+    /* Offset from binary base; dereference once to get the object ptr.   */
+    /* ------------------------------------------------------------------ */
+
+    uintptr_t eocserver_ptr;            // esv::EocServer::m_ptr
+    uintptr_t eocclient_ptr;            // ecl::EocClient::m_ptr
+    uintptr_t spell_proto_mgr_ptr;      // SpellPrototypeManager::m_ptr
+    uintptr_t rpgstats_ptr;             // RPGStats::m_ptr
+    uintptr_t resource_mgr_ptr;         // ResourceManager::m_ptr
+    uintptr_t level_mgr_ptr;            // LevelManager::m_ptr
+    uintptr_t global_template_mgr_ptr;  // ls::GlobalTemplateManager::m_ptr
+    uintptr_t cache_template_mgr_ptr;   // CacheTemplateManager::m_ptr
+    uintptr_t level_cache_mgr_ptr;      // Level::s_CacheTemplateManager
+    uintptr_t staticdata_mstate_ptr;    // ImmutableDataHeadmaster::m_State
+    uintptr_t gst_ptr;                  // ls::gGlobalStringTable (FixedString pool)
+
+    /* ------------------------------------------------------------------ */
+    /* Function offsets                                                    */
+    /* Offset from binary base; cast directly to function pointer type.   */
+    /* ------------------------------------------------------------------ */
+
+    uintptr_t fn_feat_getfeats;         // FeatManager::GetFeats
+    uintptr_t fn_getallfeats;           // GetAllFeats (context capture)
+    uintptr_t fn_get_background;        // Get<eoc::BackgroundManager>
+    uintptr_t fn_get_origin;            // Get<eoc::OriginManager>
+    uintptr_t fn_get_class;             // Get<eoc::ClassDescriptions>
+    uintptr_t fn_get_progression;       // Get<eoc::ProgressionManager>
+    uintptr_t fn_get_actionresource;    // Get<eoc::ActionResourceTypes>
+    uintptr_t fn_get_template_raw;      // GlobalTemplateManager::GetTemplateRaw
+    uintptr_t fn_cache_template;        // CacheTemplateManagerBase::CacheTemplate
+
+    /* ------------------------------------------------------------------ */
+    /* Entity system                                                       */
+    /* ------------------------------------------------------------------ */
+
+    uintptr_t fn_try_get_uuid_mapping;  // ecs::legacy::Helper::TryGetSingleton<uuid::ToHandleMappingComponent>
+    uintptr_t fn_storage_tryget;        // ecs::EntityStorageContainer::TryGet(EntityHandle)
+    uintptr_t fn_spell_proto_init;      // eoc::SpellPrototype::Init(FixedString const&)
+    uintptr_t component_data_shift;     // uniform delta added to component TypeId data addresses
+                                        // (also applied to the prototype-manager singleton
+                                        //  pointers in prototype_managers.c)
+                                        // (0 for the baseline version; nonzero when the
+                                        //  __DATA segment shifted, e.g. +0x8000 for 7209685)
+} VersionOffsets;
+
+/**
+ * Initialize the offset table using the already-detected game version.
+ * Must be called after version_detect_init().
+ */
+void offset_table_init(void);
+
+/**
+ * Return offsets for the running game version, or NULL if the version is not
+ * in the table (caller should fall back to degraded mode).
+ */
+const VersionOffsets *offset_table_get(void);
+
+/**
+ * Resolve a singleton offset to a runtime address.
+ * Returns NULL if binary_base is unknown or the offset is 0.
+ *
+ * Usage:
+ *   void **ptr = (void **)offset_table_resolve(off->rpgstats_ptr);
+ *   if (ptr) stats = *ptr;
+ */
+void *offset_table_resolve(uintptr_t offset);
+
+/**
+ * Resolve a function offset to a callable pointer.
+ * Returns NULL if binary_base is unknown or the offset is 0.
+ *
+ * Usage:
+ *   typedef void (*FnType)(void);
+ *   FnType fn = (FnType)offset_table_fn(off->fn_feat_getfeats);
+ */
+void *offset_table_fn(uintptr_t offset);
+
+/**
+ * Remap a hardcoded 6995620 game-function Ghidra address to the correct address
+ * for the running version. Returns the input unchanged on the baseline/unknown
+ * version; the verified equivalent on a shifted version; or 0 if the function is
+ * not in the remap table for a shifted version (caller should then disable that
+ * feature rather than call a stale address). Input/output are full Ghidra
+ * addresses (>= 0x100000000).
+ */
+uint64_t offset_table_remap_fn(uint64_t ghidra_addr_6995620);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OFFSET_TABLE_H */

--- a/src/core/version_detect.c
+++ b/src/core/version_detect.c
@@ -9,6 +9,7 @@
  */
 
 #include "version_detect.h"
+#include "offset_table.h"
 #include "logging.h"
 
 #include <stdio.h>
@@ -231,6 +232,12 @@ static bool probe_sentinel_addresses(void) {
 
 void version_detect_set_binary_base(void *base) {
     g_binary_base = base;
+    // Both version string and binary base are now available — initialize offset table.
+    offset_table_init();
+}
+
+void *version_detect_get_binary_base(void) {
+    return g_binary_base;
 }
 
 bool version_detect_addresses_safe(void) {

--- a/src/core/version_detect.h
+++ b/src/core/version_detect.h
@@ -55,6 +55,12 @@ bool version_detect_matches(void);
 void version_detect_set_binary_base(void *base);
 
 /**
+ * Get the runtime base address of the main BG3 binary.
+ * Returns NULL if version_detect_set_binary_base() hasn't been called.
+ */
+void *version_detect_get_binary_base(void);
+
+/**
  * Check if address-dependent features should be enabled.
  * Returns true if:
  *   - Version matches exactly, OR

--- a/src/entity/component_lookup.c
+++ b/src/entity/component_lookup.c
@@ -8,6 +8,7 @@
 #include "component_lookup.h"
 #include "arm64_call.h"
 #include "../core/logging.h"
+#include "../core/offset_table.h"
 
 #include <string.h>
 
@@ -41,9 +42,19 @@ bool component_lookup_init(void *entityWorld, void *binaryBase) {
         return false;
     }
 
-    // Calculate runtime address of TryGet function
-    uintptr_t runtime_addr = ADDR_STORAGE_CONTAINER_TRYGET - GHIDRA_BASE_ADDRESS + (uintptr_t)binaryBase;
-    g_TryGetFnAddr = (void *)runtime_addr;
+    // Calculate runtime address of TryGet function.
+    // CRASH GUARD: source from the per-version offset table. If the running
+    // version has no verified offset (field == 0), leave g_TryGetFnAddr NULL so
+    // component_lookup_ready() is false and component access safely returns nil
+    // instead of calling a stale address (which lands in the wrong game function
+    // and faults). The hardcoded ADDR_* is only the 6995620 fallback.
+    const VersionOffsets *off = offset_table_get();
+    if (off && off->fn_storage_tryget) {
+        g_TryGetFnAddr = (void *)((uintptr_t)binaryBase + off->fn_storage_tryget);
+    } else {
+        g_TryGetFnAddr = NULL;
+        LOG_ENTITY_DEBUG("StorageContainer::TryGet disabled: no verified offset for this version");
+    }
 
     LOG_ENTITY_DEBUG("Initialized:");
     LOG_ENTITY_DEBUG("  EntityWorld: %p", g_EntityWorld);

--- a/src/entity/component_registry.c
+++ b/src/entity/component_registry.c
@@ -11,6 +11,7 @@
 #include "arm64_call.h"
 #include "entity_system.h"
 #include "../core/logging.h"
+#include "../core/offset_table.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -363,7 +364,10 @@ void *component_get_by_name(void *entityWorld, uint64_t entityHandle,
     // Strategy 2: Try direct template call if we have a known address
     // Note: On macOS, template functions are inlined so this DOES NOT WORK.
     // Keeping for potential future use if we find non-inlined templates.
-    uintptr_t ghidra_addr = component_template_lookup(componentName);
+    // Remap the hardcoded 6995620 address; on a shifted version these GetComponent<T>
+    // addresses aren't remapped (returns 0) so this dead path is skipped rather
+    // than jumping to a stale function.
+    uintptr_t ghidra_addr = (uintptr_t)offset_table_remap_fn(component_template_lookup(componentName));
     if (ghidra_addr != 0) {
         void *binary_base = entity_get_binary_base();
         if (binary_base) {

--- a/src/entity/component_typeid.c
+++ b/src/entity/component_typeid.c
@@ -11,6 +11,7 @@
 #include "entity_storage.h"  // For GHIDRA_BASE_ADDRESS
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/offset_table.h"  // For per-version component_data_shift
 
 #include <string.h>
 
@@ -306,8 +307,12 @@ bool component_typeid_read(uint64_t ghidraAddr, uint16_t *outIndex) {
     }
 
     /* Calculate runtime address
-     * Formula: runtime = ghidra - 0x100000000 + binary_base */
+     * Formula: runtime = ghidra - 0x100000000 + binary_base + per-version data shift.
+     * The TypeId globals live in __DATA, which can shift uniformly between game
+     * versions (e.g. +0x8000 for 7209685); component_data_shift carries that delta. */
     uint64_t offset = ghidraAddr - GHIDRA_BASE_ADDRESS;
+    const VersionOffsets *vo = offset_table_get();
+    if (vo) offset += vo->component_data_shift;
     mach_vm_address_t runtimeAddr = offset + (mach_vm_address_t)g_BinaryBase;
 
     /* Validate the runtime address before attempting to read */
@@ -361,8 +366,10 @@ bool component_typeid_read_pointer(uint64_t ghidraAddr, uint16_t *outIndex) {
         return false;
     }
 
-    /* Calculate runtime address of the pointer */
+    /* Calculate runtime address of the pointer (with per-version data shift) */
     uint64_t offset = ghidraAddr - GHIDRA_BASE_ADDRESS;
+    const VersionOffsets *vo = offset_table_get();
+    if (vo) offset += vo->component_data_shift;
     mach_vm_address_t ptrAddr = offset + (mach_vm_address_t)g_BinaryBase;
 
     /* Validate the pointer address */
@@ -514,7 +521,10 @@ void component_typeid_dump_to_console(void) {
         const TypeIdEntry *entry = &g_KnownTypeIds[i];
         total++;
 
-        mach_vm_address_t runtimeAddr = entry->ghidraAddr - GHIDRA_BASE_ADDRESS + (mach_vm_address_t)g_BinaryBase;
+        const VersionOffsets *vo = offset_table_get();
+        mach_vm_address_t runtimeAddr = entry->ghidraAddr - GHIDRA_BASE_ADDRESS
+                                        + (vo ? vo->component_data_shift : 0)
+                                        + (mach_vm_address_t)g_BinaryBase;
 
         // Check if address is readable
         SafeMemoryInfo info = safe_memory_check_address(runtimeAddr);
@@ -561,7 +571,10 @@ void component_typeid_dump(void) {
     for (int i = 0; g_KnownTypeIds[i].componentName != NULL; i++) {
         const TypeIdEntry *entry = &g_KnownTypeIds[i];
 
-        mach_vm_address_t runtimeAddr = entry->ghidraAddr - GHIDRA_BASE_ADDRESS + (mach_vm_address_t)g_BinaryBase;
+        const VersionOffsets *vo = offset_table_get();
+        mach_vm_address_t runtimeAddr = entry->ghidraAddr - GHIDRA_BASE_ADDRESS
+                                        + (vo ? vo->component_data_shift : 0)
+                                        + (mach_vm_address_t)g_BinaryBase;
 
         LOG_ENTITY_DEBUG("  %s:", entry->componentName);
         LOG_ENTITY_DEBUG("    Ghidra addr: 0x%llx", (unsigned long long)entry->ghidraAddr);

--- a/src/entity/entity_system.c
+++ b/src/entity/entity_system.c
@@ -14,6 +14,7 @@
 #include "arm64_call.h"
 #include "logging.h"
 #include "../core/version_detect.h"
+#include "../core/offset_table.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -459,10 +460,20 @@ static void *read_eocserver_from_global(void) {
         return NULL;
     }
 
-    // Calculate runtime address of esv::EocServer::m_ptr
+    // Calculate runtime address of esv::EocServer::m_ptr.
+    // Prefer the per-version offset table (eocserver_ptr); fall back to the
+    // hardcoded 6995620 address only if the version is unknown. Using the stale
+    // hardcoded value on a shifted version reads the wrong slot -> garbage
+    // EoCServer -> garbage EntityWorld -> crash inside the ECS query.
     uintptr_t ghidra_base = GHIDRA_BASE_ADDRESS;
     uintptr_t actual_base = (uintptr_t)g_MainBinaryBase;
-    uintptr_t global_addr = OFFSET_EOCSERVER_SINGLETON_PTR - ghidra_base + actual_base;
+    uintptr_t global_addr;
+    const VersionOffsets *off = offset_table_get();
+    if (off && off->eocserver_ptr) {
+        global_addr = actual_base + off->eocserver_ptr;
+    } else {
+        global_addr = OFFSET_EOCSERVER_SINGLETON_PTR - ghidra_base + actual_base;
+    }
 
     LOG_ENTITY_DEBUG("Reading EoCServer from global at 0x%llx", (unsigned long long)global_addr);
     LOG_ENTITY_DEBUG("  (Ghidra offset: 0x%llx, base: %p)",
@@ -1001,9 +1012,22 @@ int entity_system_init(void *main_binary_base) {
     LOG_ENTITY_DEBUG("Main binary hooks disabled (macOS memory protection issues)");
     LOG_ENTITY_DEBUG("EntityWorld must be set manually via Ext.Entity.SetWorldPtr() or discovered via Osiris hooks");
 
-    // Set up function pointers for component accessors and singleton getters
-    // These don't need hooks - we just need to know where to call
-    g_TryGetUuidMappingSingleton = (TryGetSingletonFn)(OFFSET_TRY_GET_UUID_MAPPING_SINGLETON - ghidra_base + actual_base);
+    // Set up function pointers for component accessors and singleton getters.
+    // CRASH GUARD: source the UUID-mapping singleton getter from the per-version
+    // offset table. If the running version has no *verified* offset (field == 0),
+    // the pointer stays NULL and entity_get_by_guid safely no-ops instead of
+    // calling a stale address (which is valid-but-wrong code and would crash).
+    // The hardcoded OFFSET_* below is only the 6995620 fallback.
+    {
+        const VersionOffsets *off = offset_table_get();
+        if (off && off->fn_try_get_uuid_mapping) {
+            g_TryGetUuidMappingSingleton =
+                (TryGetSingletonFn)offset_table_fn(off->fn_try_get_uuid_mapping);
+        } else {
+            g_TryGetUuidMappingSingleton = NULL;
+            LOG_ENTITY_DEBUG("UUID-mapping getter disabled: no verified offset for this version");
+        }
+    }
 
     // ls:: components - all DISABLED until addresses are verified via Ghidra
     // When offset is 0, pointer stays NULL (safe)

--- a/src/game/global_switches.c
+++ b/src/game/global_switches.c
@@ -1,6 +1,7 @@
 #include "global_switches.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/offset_table.h"
 #include <dispatch/dispatch.h>
 #include <mach-o/dyld.h>
 #include <string.h>
@@ -36,7 +37,12 @@ bool global_switches_init(void) {
     }
 
     uintptr_t slide = base - 0x100000000;
-    uintptr_t ptr_addr = GLOBAL_SWITCHES_PTR_VA + slide;
+    // The switches pointer slot is a __DATA global -> apply the per-version data
+    // shift. This read is safe (safe_memory_read_pointer), so a wrong address
+    // just fails gracefully rather than crashing.
+    const VersionOffsets *vo = offset_table_get();
+    uintptr_t data_shift = vo ? vo->component_data_shift : 0;
+    uintptr_t ptr_addr = GLOBAL_SWITCHES_PTR_VA + slide + data_shift;
 
     void *ptr_val = NULL;
     if (!safe_memory_read_pointer((mach_vm_address_t)ptr_addr, &ptr_val)) {

--- a/src/hooks/arm64_hook.c
+++ b/src/hooks/arm64_hook.c
@@ -17,6 +17,7 @@
 #include <sys/mman.h>
 #include <mach/mach.h>
 #include <libkern/OSCacheControl.h>
+#include <pthread.h>   // pthread_jit_write_protect_np (Apple Silicon W^X for MAP_JIT)
 
 // =============================================================================
 // Module State
@@ -321,6 +322,13 @@ ARM64HookHandle* arm64_hook_at_offset(void* target, int skip_bytes, void* replac
     uint32_t* tramp = (uint32_t*)handle->trampoline;
     int tramp_idx = 0;
 
+    // The trampoline is a MAP_JIT page. On Apple Silicon, MAP_JIT pages are
+    // execute-protected per-thread by default; we must disable JIT write
+    // protection before writing and re-enable it (then flush icache) after.
+    // Without this, the memcpy below faults with KERN_PROTECTION_FAILURE on
+    // recent macOS (e.g. 26.x). No-op on Intel.
+    pthread_jit_write_protect_np(0);  // make MAP_JIT writable on this thread
+
     // Copy skipped prologue (runs first when calling original)
     if (skip_bytes > 0) {
         memcpy(tramp, target, skip_bytes);
@@ -341,6 +349,8 @@ ARM64HookHandle* arm64_hook_at_offset(void* target, int skip_bytes, void* replac
         arm64_encode_absolute_branch(&tramp[tramp_idx], continue_addr);
         tramp_idx += 4;
     }
+
+    pthread_jit_write_protect_np(1);  // re-protect (execute) before running
 
     // Flush trampoline cache
     sys_icache_invalidate(handle->trampoline, tramp_idx * 4);

--- a/src/level/level_manager.c
+++ b/src/level/level_manager.c
@@ -15,15 +15,14 @@
 #include "level_manager.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/offset_table.h"
 #include <string.h>
 
 // ============================================================================
 // Constants and Offsets
 // ============================================================================
 
-// LevelManager::m_ptr global singleton
-// Same address used in template_manager.c
-#define OFFSET_LEVEL_MANAGER_PTR    0x08a3be40
+// LevelManager::m_ptr — sourced from offset_table at runtime
 
 // LevelManager internal offsets (need ARM64 runtime verification)
 #define LEVELMANAGER_CURRENT_LEVEL_OFFSET   0x90   // EoCLevel* CurrentLevel
@@ -76,12 +75,20 @@ bool level_manager_init(void *main_binary_base) {
     }
 
     g_level.main_binary_base = main_binary_base;
-    g_level.level_manager_ptr = (void **)((uintptr_t)main_binary_base + OFFSET_LEVEL_MANAGER_PTR);
+
+    const VersionOffsets *off = offset_table_get();
+    if (!off || !off->level_mgr_ptr) {
+        log_message("[Level] WARN: level_mgr_ptr not available for this BG3 version — Level API disabled");
+        g_level.initialized = true;
+        return true;  // Not a fatal error; Level APIs will return NULL gracefully
+    }
+
+    g_level.level_manager_ptr = (void **)offset_table_resolve(off->level_mgr_ptr);
 
     log_message("[Level] Level manager initialized");
     log_message("[Level]   Base: %p", main_binary_base);
-    log_message("[Level]   LevelManager::m_ptr at offset 0x%x -> %p",
-                OFFSET_LEVEL_MANAGER_PTR, (void *)g_level.level_manager_ptr);
+    log_message("[Level]   LevelManager::m_ptr at offset 0x%llx -> %p",
+                (unsigned long long)off->level_mgr_ptr, (void *)g_level.level_manager_ptr);
 
     g_level.initialized = true;
     return true;

--- a/src/localization/localization.c
+++ b/src/localization/localization.c
@@ -20,6 +20,7 @@
 #include "localization.h"
 #include "logging.h"
 #include "fixed_string.h"
+#include "../core/offset_table.h"
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -133,13 +134,21 @@ void localization_init(void *main_binary_base) {
 
     s_loca.binary_base = main_binary_base;
 
-    // Calculate address of ls::TranslatedStringRepository::m_ptr
-    s_loca.repo_ptr_addr = (void**)((uintptr_t)main_binary_base + LOCA_REPO_OFFSET);
+    // The repository m_ptr is a __DATA global -> apply the per-version data shift.
+    const VersionOffsets *vo = offset_table_get();
+    uintptr_t data_shift = vo ? vo->component_data_shift : 0;
+    s_loca.repo_ptr_addr = (void**)((uintptr_t)main_binary_base + LOCA_REPO_OFFSET + data_shift);
 
-    // Calculate function addresses
-    s_loca.fs_create = (FixedStringCreateFn)((uintptr_t)main_binary_base + LOCA_FIXEDSTRING_CREATE);
-    s_loca.tryget_fn = (void*)((uintptr_t)main_binary_base + LOCA_TRYGET_OFFSET);
-    s_loca.add_string_fn = (AddTranslatedStringFn)((uintptr_t)main_binary_base + LOCA_ADDTRANSLATEDSTRING);
+    // The functions are __TEXT -> remap each hardcoded 6995620 address. If a
+    // function has no verified address for this version, leave it NULL so the
+    // caller skips it instead of jumping to a stale address.
+    #define LOCA_FN(off) ({ \
+        uint64_t _a = offset_table_remap_fn(0x100000000ULL + (off)); \
+        _a ? (void*)((uintptr_t)main_binary_base + (_a - 0x100000000ULL)) : NULL; })
+    s_loca.fs_create     = (FixedStringCreateFn)LOCA_FN(LOCA_FIXEDSTRING_CREATE);
+    s_loca.tryget_fn     = LOCA_FN(LOCA_TRYGET_OFFSET);
+    s_loca.add_string_fn = (AddTranslatedStringFn)LOCA_FN(LOCA_ADDTRANSLATEDSTRING);
+    #undef LOCA_FN
 
     LOG_CORE_INFO("LOCA: Initialized - repo_ptr at %p", (void*)s_loca.repo_ptr_addr);
     LOG_CORE_DEBUG("LOCA: FixedString::Create at %p", (void*)s_loca.fs_create);

--- a/src/network/net_hooks.c
+++ b/src/network/net_hooks.c
@@ -23,6 +23,7 @@
 #include "network_backend.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/offset_table.h"
 #include "../game/game_state.h"        // game_state_get_current()
 #include "../entity/entity_system.h"   // entity_get_binary_base(), entity_get_eoc_server()
 #include <dobby.h>
@@ -96,7 +97,11 @@ static bool safe_read_u64(const void *base, uintptr_t offset, uint64_t *out) {
 static uintptr_t get_runtime_addr(uintptr_t ghidra_addr) {
     void *base = entity_get_binary_base();
     if (!base) return 0;
-    return ghidra_addr - GHIDRA_BASE_ADDRESS + (uintptr_t)base;
+    // Remap the hardcoded 6995620 address to the running version (0 = no verified
+    // address -> caller skips the hook rather than hooking a stale function).
+    uint64_t remapped = offset_table_remap_fn(ghidra_addr);
+    if (!remapped) return 0;
+    return remapped - GHIDRA_BASE_ADDRESS + (uintptr_t)base;
 }
 
 // ============================================================================

--- a/src/resource/resource_manager.c
+++ b/src/resource/resource_manager.c
@@ -7,6 +7,7 @@
 #include "resource_manager.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/offset_table.h"
 #include "../strings/fixed_string.h"
 #include <string.h>
 #include <strings.h>
@@ -102,8 +103,12 @@ bool resource_manager_init(void *main_binary_base) {
 
     g_resource.main_binary_base = main_binary_base;
 
-    // Calculate runtime address of ResourceManager global pointer
-    g_resource.resource_manager_ptr = (void**)((uintptr_t)main_binary_base + OFFSET_RESOURCEMANAGER_PTR);
+    const VersionOffsets *off = offset_table_get();
+    if (off && off->resource_mgr_ptr) {
+        g_resource.resource_manager_ptr = (void**)offset_table_resolve(off->resource_mgr_ptr);
+    } else {
+        g_resource.resource_manager_ptr = (void**)((uintptr_t)main_binary_base + OFFSET_RESOURCEMANAGER_PTR);
+    }
 
     log_message("[Resource] Resource manager initialized");
     log_message("[Resource]   Base: %p", main_binary_base);
@@ -217,9 +222,15 @@ void* resource_get(ResourceBankType type, uint32_t fixed_string_id) {
         return NULL;
     }
 
-    // Call GetResource function
-    // Function address = base + offset
-    GetResourceFunc get_resource = (GetResourceFunc)((uintptr_t)g_resource.main_binary_base + OFFSET_GETRESOURCE_FUNC);
+    // Resolve GetResource for the running version (remap the hardcoded 6995620
+    // address; 0 = no verified address for this version -> bail instead of
+    // calling a stale function).
+    uint64_t fn_ghidra = offset_table_remap_fn(0x100000000ULL + OFFSET_GETRESOURCE_FUNC);
+    if (!fn_ghidra) {
+        return NULL;
+    }
+    GetResourceFunc get_resource = (GetResourceFunc)((uintptr_t)g_resource.main_binary_base
+                                                     + (fn_ghidra - 0x100000000ULL));
 
     // Note: FixedString is passed as pointer to its hash value
     void* result = get_resource(bank, (uint32_t)type, &fixed_string_id);

--- a/src/staticdata/staticdata_manager.c
+++ b/src/staticdata/staticdata_manager.c
@@ -8,6 +8,7 @@
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
 #include "../core/version_detect.h"
+#include "../core/offset_table.h"
 #include "../strings/fixed_string.h"
 #include "../hooks/arm64_hook.h"
 #include <dobby.h>
@@ -17,23 +18,14 @@
 #include <ctype.h>
 
 // ============================================================================
-// Constants and Offsets (Discovered via Ghidra)
+// Constants and Offsets
 // ============================================================================
-
-// Function addresses (relative to base)
-#define OFFSET_FEAT_GETFEATS          0x01b752b4  // FeatManager::GetFeats
-#define OFFSET_GETALLFEATS            0x0120b3e8  // GetAllFeats (for context capture)
-
-// ImmutableDataHeadmaster m_State pointer address (for TypeContext traversal)
-#define OFFSET_MSTATE_PTR             0x083c4a68  // PTR_m_State - pointer to m_State
-
-// Get<T> function addresses (for real manager capture - Dec 22, 2025)
-// These functions return the real manager pointers from ImmutableDataHeadmaster
-#define OFFSET_GET_BACKGROUND         0x02994834  // Get<eoc::BackgroundManager>
-#define OFFSET_GET_ORIGIN             0x0341c42c  // Get<eoc::OriginManager>
-#define OFFSET_GET_CLASS              0x0262f184  // Get<eoc::ClassDescriptions>
-#define OFFSET_GET_PROGRESSION        0x03697f0c  // Get<eoc::ProgressionManager>
-#define OFFSET_GET_ACTIONRESOURCE     0x011a4494  // Get<eoc::ActionResourceTypes>
+//
+// All address-dependent values (the m_State pointer, the FeatManager::GetFeats
+// and GetAllFeats functions, and the ImmutableDataHeadmaster::Get<T> accessors)
+// are sourced per game version from src/core/offset_table.c. See the
+// VersionOffsets fields: staticdata_mstate_ptr, fn_feat_getfeats,
+// fn_getallfeats, fn_get_background/origin/class/progression/actionresource.
 
 // FeatManager structure offsets
 //
@@ -342,9 +334,14 @@ static int capture_managers_via_typecontext(void) {
         return 0;
     }
 
-    // Safely get pointer to m_State
+    // Safely get pointer to m_State (address from per-version offset table)
+    const VersionOffsets *off = offset_table_get();
+    if (!off || !off->staticdata_mstate_ptr) {
+        log_message("[StaticData] staticdata_mstate_ptr not available for this version");
+        return 0;
+    }
     void* m_state = NULL;
-    mach_vm_address_t ptr_mstate_addr = (mach_vm_address_t)g_staticdata.main_binary_base + OFFSET_MSTATE_PTR;
+    mach_vm_address_t ptr_mstate_addr = (mach_vm_address_t)offset_table_resolve(off->staticdata_mstate_ptr);
     if (!safe_memory_read_pointer(ptr_mstate_addr, &m_state)) {
         log_message("[StaticData] Could not read m_State pointer at %p", (void*)ptr_mstate_addr);
         return 0;
@@ -434,9 +431,13 @@ static void* find_manager_via_typecontext(const char* type_name) {
         return NULL;
     }
 
-    // Get pointer to m_State
-    void** ptr_mstate = (void**)((uint8_t*)g_staticdata.main_binary_base + OFFSET_MSTATE_PTR);
-    void* m_state = *ptr_mstate;
+    // Get pointer to m_State (address from per-version offset table)
+    const VersionOffsets *off = offset_table_get();
+    if (!off || !off->staticdata_mstate_ptr) {
+        return NULL;
+    }
+    void** ptr_mstate = (void**)offset_table_resolve(off->staticdata_mstate_ptr);
+    void* m_state = ptr_mstate ? *ptr_mstate : NULL;
     if (!m_state) {
         log_message("[StaticData] m_State is NULL");
         return NULL;
@@ -685,47 +686,47 @@ static void* hook_GetActionResource(void* headmaster) {
  * Uses standard Dobby hooks (Get<T> functions are small and typically safe).
  */
 static void install_get_manager_hooks(void* main_binary_base) {
+    (void)main_binary_base;  // address now sourced from offset_table
+    const VersionOffsets *off = offset_table_get();
+    if (!off) {
+        log_message("[StaticData] Get<T> hooks SKIPPED (no offset table entry for this version)");
+        return;
+    }
+
+    // CRASH GUARD: these Get<T> accessors are hooked with PLAIN DobbyHook, which
+    // mangles their PC-relative (adrp/cbz) prologue on shifted versions — the
+    // trampoline then returns a garbage manager and the character-progression
+    // validator calls through a bad pointer (e.g. Barbarian level 2->3 subclass
+    // pick -> SIGBUS, with zero SE frames in the stack). Only install on the
+    // exact baseline version where DobbyHook is known-safe. On other versions the
+    // TypeContext traversal (capture_managers_via_typecontext) already captures
+    // these managers without hooking, so StaticData degrades gracefully.
+    // (Proper future fix: give Get<T> the same ADRP-safe install FeatManager uses.)
+    if (!version_detect_matches()) {
+        log_message("[StaticData] Get<T> code hooks SKIPPED on this version "
+                    "(plain DobbyHook is prologue-unsafe) — using TypeContext traversal only");
+        return;
+    }
+
     log_message("[StaticData] Installing Get<T> hooks for real manager capture...");
+    void* target;
 
-    // Background
-    void* target = (uint8_t*)main_binary_base + OFFSET_GET_BACKGROUND;
-    if (DobbyHook(target, (void*)hook_GetBackground, (void**)&g_orig_GetBackground) == 0) {
-        log_message("[StaticData] Installed Get<BackgroundManager> hook at %p", target);
-    } else {
-        log_message("[StaticData] WARNING: Failed to hook Get<BackgroundManager>");
+#define INSTALL_HOOK(field, fn_hook, fn_orig, label) \
+    if (off->field) { \
+        target = offset_table_fn(off->field); \
+        if (DobbyHook(target, (void*)(fn_hook), (void**)(fn_orig)) == 0) \
+            log_message("[StaticData] Installed " label " hook at %p", target); \
+        else \
+            log_message("[StaticData] WARNING: Failed to hook " label); \
     }
 
-    // Origin
-    target = (uint8_t*)main_binary_base + OFFSET_GET_ORIGIN;
-    if (DobbyHook(target, (void*)hook_GetOrigin, (void**)&g_orig_GetOrigin) == 0) {
-        log_message("[StaticData] Installed Get<OriginManager> hook at %p", target);
-    } else {
-        log_message("[StaticData] WARNING: Failed to hook Get<OriginManager>");
-    }
+    INSTALL_HOOK(fn_get_background,    hook_GetBackground,    &g_orig_GetBackground,    "Get<BackgroundManager>")
+    INSTALL_HOOK(fn_get_origin,        hook_GetOrigin,        &g_orig_GetOrigin,        "Get<OriginManager>")
+    INSTALL_HOOK(fn_get_class,         hook_GetClass,         &g_orig_GetClass,         "Get<ClassDescriptions>")
+    INSTALL_HOOK(fn_get_progression,   hook_GetProgression,   &g_orig_GetProgression,   "Get<ProgressionManager>")
+    INSTALL_HOOK(fn_get_actionresource,hook_GetActionResource,&g_orig_GetActionResource,"Get<ActionResourceTypes>")
 
-    // Class
-    target = (uint8_t*)main_binary_base + OFFSET_GET_CLASS;
-    if (DobbyHook(target, (void*)hook_GetClass, (void**)&g_orig_GetClass) == 0) {
-        log_message("[StaticData] Installed Get<ClassDescriptions> hook at %p", target);
-    } else {
-        log_message("[StaticData] WARNING: Failed to hook Get<ClassDescriptions>");
-    }
-
-    // Progression
-    target = (uint8_t*)main_binary_base + OFFSET_GET_PROGRESSION;
-    if (DobbyHook(target, (void*)hook_GetProgression, (void**)&g_orig_GetProgression) == 0) {
-        log_message("[StaticData] Installed Get<ProgressionManager> hook at %p", target);
-    } else {
-        log_message("[StaticData] WARNING: Failed to hook Get<ProgressionManager>");
-    }
-
-    // ActionResource
-    target = (uint8_t*)main_binary_base + OFFSET_GET_ACTIONRESOURCE;
-    if (DobbyHook(target, (void*)hook_GetActionResource, (void**)&g_orig_GetActionResource) == 0) {
-        log_message("[StaticData] Installed Get<ActionResourceTypes> hook at %p", target);
-    } else {
-        log_message("[StaticData] WARNING: Failed to hook Get<ActionResourceTypes>");
-    }
+#undef INSTALL_HOOK
 
     log_message("[StaticData] Get<T> hooks installation complete");
 }
@@ -977,7 +978,26 @@ int staticdata_hash_lookup_capture(void) {
  * Returns true if hook was installed successfully.
  */
 static bool install_feat_getfeats_safe_hook(void* main_binary_base) {
-    void* target = (uint8_t*)main_binary_base + OFFSET_FEAT_GETFEATS;
+    const VersionOffsets *off = offset_table_get();
+    if (!off || !off->fn_feat_getfeats) {
+        log_message("[StaticData] FeatGetFeats offset not available for this version");
+        return false;
+    }
+
+    // CRASH GUARD: this hook fires during character level-up (it captures the
+    // session FeatManager). Even the ARM64-safe hook's trampoline is not proven
+    // correct on shifted prologues — a corrupted accessor crashes the level-up
+    // validator (ApplyAndValidateLevelUp -> indirect call to garbage; zero SE
+    // frames). Only install on the exact baseline version where it's verified.
+    // On other versions StaticData captures FeatManager via the TypeContext
+    // traversal instead (no hooking). Restores the pre-offset-table-fill behavior.
+    if (!version_detect_matches()) {
+        log_message("[StaticData] FeatManager::GetFeats hook SKIPPED on this version "
+                    "(hook trampoline unverified) — using TypeContext traversal only");
+        return false;
+    }
+
+    void* target = offset_table_fn(off->fn_feat_getfeats);
 
     // First, analyze the prologue to understand the ADRP patterns
     log_message("[StaticData] Analyzing FeatManager::GetFeats prologue at %p", target);
@@ -1044,19 +1064,16 @@ bool staticdata_manager_init(void *main_binary_base) {
     memset(g_staticdata.managers, 0, sizeof(g_staticdata.managers));
     memset(g_staticdata.real_managers, 0, sizeof(g_staticdata.real_managers));
 
-    // Manager capture installs inline Dobby CODE hooks at hardcoded main-binary
-    // offsets (OFFSET_FEAT_GETFEATS, OFFSET_GET_*). Those offsets are only valid
-    // for the exact verified build (BG3_KNOWN_VERSION). On a version mismatch the
-    // targets are stale and DobbyHook overwrites whatever instructions now live
-    // there, corrupting unrelated game code — the root cause of the
-    // esv::hotbar::System crash on new-game load (Issue #78). Sentinel probes
-    // validate DATA reads, not code addresses, so a passing probe is NOT enough to
-    // make code patching safe; gate hook installation on an EXACT version match
-    // (same policy as functor hooks in main.c). Without the hooks the manager
-    // degrades gracefully — it reports 0 captured managers instead of crashing.
-    if (!version_detect_matches()) {
-        log_message("[StaticData] Manager hooks SKIPPED (game version mismatch — "
-                    "code patching unsafe; Ext.StaticData runs in degraded mode)");
+    // Manager capture installs inline Dobby CODE hooks at function addresses.
+    // Addresses are sourced from the offset table (keyed by game version).
+    // A missing table entry means 0 offsets → hooks are individually skipped.
+    // This replaced the old exact-version-match gate (Issue #78) with a
+    // per-version table so new BG3 versions can be supported without source changes.
+    const VersionOffsets *off = offset_table_get();
+    if (!off || (!off->fn_feat_getfeats && !off->fn_get_background)) {
+        log_message("[StaticData] Manager hooks SKIPPED (no function offsets for version %s — "
+                    "add to offset_table.c to enable; Ext.StaticData in degraded mode)",
+                    version_detect_get_version() ? version_detect_get_version() : "unknown");
         g_staticdata.initialized = true;
         return true;
     }

--- a/src/staticdata/staticdata_manager.c
+++ b/src/staticdata/staticdata_manager.c
@@ -7,6 +7,7 @@
 #include "staticdata_manager.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/version_detect.h"
 #include "../strings/fixed_string.h"
 #include "../hooks/arm64_hook.h"
 #include <dobby.h>
@@ -1042,6 +1043,23 @@ bool staticdata_manager_init(void *main_binary_base) {
     // Clear manager pointers
     memset(g_staticdata.managers, 0, sizeof(g_staticdata.managers));
     memset(g_staticdata.real_managers, 0, sizeof(g_staticdata.real_managers));
+
+    // Manager capture installs inline Dobby CODE hooks at hardcoded main-binary
+    // offsets (OFFSET_FEAT_GETFEATS, OFFSET_GET_*). Those offsets are only valid
+    // for the exact verified build (BG3_KNOWN_VERSION). On a version mismatch the
+    // targets are stale and DobbyHook overwrites whatever instructions now live
+    // there, corrupting unrelated game code — the root cause of the
+    // esv::hotbar::System crash on new-game load (Issue #78). Sentinel probes
+    // validate DATA reads, not code addresses, so a passing probe is NOT enough to
+    // make code patching safe; gate hook installation on an EXACT version match
+    // (same policy as functor hooks in main.c). Without the hooks the manager
+    // degrades gracefully — it reports 0 captured managers instead of crashing.
+    if (!version_detect_matches()) {
+        log_message("[StaticData] Manager hooks SKIPPED (game version mismatch — "
+                    "code patching unsafe; Ext.StaticData runs in degraded mode)");
+        g_staticdata.initialized = true;
+        return true;
+    }
 
     // Try to install ARM64-safe hook for FeatManager::GetFeats
     // This uses the skip-and-redirect strategy from Issue #44

--- a/src/stats/functor_hooks.c
+++ b/src/stats/functor_hooks.c
@@ -17,6 +17,7 @@
 #include "functor_hooks.h"
 #include "functor_types.h"
 #include "../core/logging.h"
+#include "../core/offset_table.h"
 #include "../lua/lua_events.h"
 #include "../entity/entity_storage.h"
 
@@ -53,7 +54,11 @@ extern void* entity_get_binary_base(void);
 static uintptr_t get_runtime_addr(uintptr_t ghidra_addr) {
     void* base = entity_get_binary_base();
     if (!base) return 0;
-    return ghidra_addr - GHIDRA_BASE_ADDRESS + (uintptr_t)base;
+    // Remap the hardcoded 6995620 address to the running version (0 = no verified
+    // address -> caller skips the hook instead of hooking a stale function).
+    uint64_t remapped = offset_table_remap_fn(ghidra_addr);
+    if (!remapped) return 0;
+    return remapped - GHIDRA_BASE_ADDRESS + (uintptr_t)base;
 }
 
 // =============================================================================

--- a/src/stats/prototype_managers.c
+++ b/src/stats/prototype_managers.c
@@ -9,6 +9,7 @@
 #include "stats_manager.h"
 #include "logging.h"
 #include "../core/version_detect.h"
+#include "../core/offset_table.h"
 #include "../strings/fixed_string.h"
 
 #include <stdio.h>
@@ -169,9 +170,16 @@ static SpellPrototypeInit_fn g_SpellPrototypeInit = NULL;
 // Helper: Calculate runtime address from Ghidra offset
 // ============================================================================
 
+// Resolve a __DATA Ghidra address (prototype-manager singleton pointer) to a
+// runtime address, applying the per-version __DATA shift (e.g. +0x8000 for
+// 7209685). All callers of this helper are __DATA globals; the Init *function*
+// (a __TEXT address with a different per-version shift) is resolved separately
+// via the offset table.
 static void* ghidra_to_runtime(uint64_t ghidra_addr) {
     if (!g_MainBinaryBase) return NULL;
-    return (void*)((uintptr_t)g_MainBinaryBase + (ghidra_addr - GHIDRA_BASE_ADDRESS));
+    const VersionOffsets *off = offset_table_get();
+    uintptr_t shift = off ? off->component_data_shift : 0;
+    return (void*)((uintptr_t)g_MainBinaryBase + (ghidra_addr - GHIDRA_BASE_ADDRESS) + shift);
 }
 
 // ============================================================================
@@ -229,11 +237,19 @@ bool prototype_managers_init(void *main_binary_base) {
                     (void*)g_pStatusPrototypeManagerPtr,
                     (unsigned long long)OFFSET_STATUS_PROTOTYPE_MANAGER_PTR);
 
-    // Resolve Init function pointers
-    g_SpellPrototypeInit = (SpellPrototypeInit_fn)ghidra_to_runtime(OFFSET_SPELL_PROTOTYPE_INIT);
-    LOG_STATS_DEBUG("[PrototypeManagers] SpellPrototype::Init at: %p (Ghidra: 0x%llx)",
-                    (void*)g_SpellPrototypeInit,
-                    (unsigned long long)OFFSET_SPELL_PROTOTYPE_INIT);
+    // Resolve Init function pointer from the per-version offset table (it's a
+    // __TEXT address with a version-specific shift different from __DATA, so it
+    // can't go through ghidra_to_runtime). If unavailable, leave NULL so
+    // sync_spell_prototype skips the Init call instead of jumping to a stale
+    // address (the bug that crashed Ext.Stats.Sync on 7209685).
+    {
+        const VersionOffsets *off = offset_table_get();
+        g_SpellPrototypeInit = (off && off->fn_spell_proto_init)
+            ? (SpellPrototypeInit_fn)offset_table_fn(off->fn_spell_proto_init)
+            : NULL;
+        LOG_STATS_DEBUG("[PrototypeManagers] SpellPrototype::Init at: %p",
+                        (void*)g_SpellPrototypeInit);
+    }
 
     g_Initialized = true;
     LOG_STATS_DEBUG("[PrototypeManagers] Initialization complete");

--- a/src/stats/stats_manager.c
+++ b/src/stats/stats_manager.c
@@ -16,6 +16,8 @@
 #include "prototype_managers.h"
 #include "logging.h"
 #include "../strings/fixed_string.h"
+#include "../core/offset_table.h"
+#include "../game/game_state.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -283,14 +285,21 @@ void stats_manager_init(void *main_binary_base) {
         }
     }
 
-    // Fallback: Calculate from Ghidra offset
+    // Fallback: use offset table (version-keyed), then old Ghidra absolute if nothing else
     if (!g_pRPGStatsPtr && main_binary_base) {
-        uintptr_t runtime_addr = (uintptr_t)main_binary_base +
-                                  (OFFSET_RPGSTATS_M_PTR - GHIDRA_BASE_ADDRESS);
-        g_pRPGStatsPtr = (void**)runtime_addr;
-        LOG_STATS_DEBUG("Using Ghidra offset: %p (base %p + offset 0x%llx)",
-                  (void*)g_pRPGStatsPtr, main_binary_base,
-                  (unsigned long long)(OFFSET_RPGSTATS_M_PTR - GHIDRA_BASE_ADDRESS));
+        const VersionOffsets *off = offset_table_get();
+        if (off && off->rpgstats_ptr) {
+            g_pRPGStatsPtr = (void**)offset_table_resolve(off->rpgstats_ptr);
+            LOG_STATS_DEBUG("Using offset table: %p (offset 0x%llx)",
+                      (void*)g_pRPGStatsPtr, (unsigned long long)off->rpgstats_ptr);
+        } else {
+            uintptr_t runtime_addr = (uintptr_t)main_binary_base +
+                                      (OFFSET_RPGSTATS_M_PTR - GHIDRA_BASE_ADDRESS);
+            g_pRPGStatsPtr = (void**)runtime_addr;
+            LOG_STATS_DEBUG("Using Ghidra offset fallback: %p (base %p + offset 0x%llx)",
+                      (void*)g_pRPGStatsPtr, main_binary_base,
+                      (unsigned long long)(OFFSET_RPGSTATS_M_PTR - GHIDRA_BASE_ADDRESS));
+        }
     }
 
     g_Initialized = true;
@@ -1419,6 +1428,18 @@ static void* get_cached_vmt(void) {
 
 bool stats_sync(const char *name) {
     if (!name) return false;
+
+    // CRASH GUARD: stats_sync is a *mutating* op — it calls the game's
+    // SpellPrototype::Init on prototypes held in the manager's RefMap. During a
+    // session load/unload/sync the game is rebuilding those managers, so a
+    // prototype pointer can be freed mid-call (use-after-free -> SIGBUS). Only
+    // run when the server is in a stable state.
+    ServerGameState gs = game_state_get_current();
+    if (gs != SERVER_STATE_RUNNING && gs != SERVER_STATE_PAUSED) {
+        LOG_STATS_DEBUG("stats_sync: skipped for '%s' — server not stable (state=%s)",
+                        name, game_state_get_name(gs));
+        return false;
+    }
 
     // Get the stat object (shadow or game)
     StatsObjectPtr obj = stats_get(name);

--- a/src/strings/fixed_string.c
+++ b/src/strings/fixed_string.c
@@ -13,6 +13,7 @@
 #include "fixed_string.h"
 #include "../core/logging.h"
 #include "../core/version.h"
+#include "../core/offset_table.h"
 #include <mach/mach.h>
 #include <mach-o/dyld.h>
 #include <dlfcn.h>
@@ -1121,6 +1122,28 @@ void fixed_string_init(void *main_binary_base) {
     g_MainBinaryBase = main_binary_base;
     LOG_CORE_DEBUG("Initializing with binary base %p", main_binary_base);
 
+    // Highest priority: per-version offset table (authoritative; beats the
+    // stale on-disk cache and the hardcoded Ghidra fallback below). The slot
+    // holds a pointer to the GlobalStringTable.
+    {
+        const VersionOffsets *off = offset_table_get();
+        if (off && off->gst_ptr && main_binary_base) {
+            static void *gst_slot = NULL;
+            gst_slot = (void *)((uintptr_t)main_binary_base + off->gst_ptr);
+            void *gst = NULL;
+            if (safe_read_ptr(gst_slot, &gst) && gst) {
+                g_pGlobalStringTable = (void **)gst_slot;
+                LOG_CORE_DEBUG("GST from offset table: slot=%p GST=%p", gst_slot, gst);
+                if (fixed_string_probe_offsets()) {
+                    g_Initialized = true;
+                    LOG_CORE_DEBUG("Initialization complete via offset table");
+                    return;
+                }
+                g_pGlobalStringTable = NULL;  // probe failed; fall through
+            }
+        }
+    }
+
     // Try dlsym first
     g_pGlobalStringTable = try_dlsym_discovery();
 
@@ -1179,6 +1202,28 @@ static bool try_lazy_discovery(void) {
 
     LOG_CORE_DEBUG("Lazy discovery triggered on first resolution attempt...");
 
+    // Strategy 0: per-version offset table (authoritative). Re-checked here
+    // because fixed_string_init() may run before the offset table is loaded;
+    // by first resolution the table is guaranteed populated. The slot holds a
+    // pointer to the GlobalStringTable.
+    {
+        const VersionOffsets *off = offset_table_get();
+        if (off && off->gst_ptr && g_MainBinaryBase) {
+            static void *gst_slot = NULL;
+            gst_slot = (void *)((uintptr_t)g_MainBinaryBase + off->gst_ptr);
+            void *gst = NULL;
+            if (safe_read_ptr(gst_slot, &gst) && gst) {
+                g_pGlobalStringTable = (void **)gst_slot;
+                LOG_CORE_DEBUG("GST from offset table (lazy): slot=%p GST=%p", gst_slot, gst);
+                if (fixed_string_probe_offsets()) {
+                    LOG_CORE_DEBUG("Lazy discovery via offset table succeeded");
+                    return true;
+                }
+                g_pGlobalStringTable = NULL;  // probe failed; fall through
+            }
+        }
+    }
+
     // Strategy 1: Try to load from cache (instant - no scanning needed)
     if (load_offset_cache() && g_CachedGSTOffset != 0 && g_MainBinaryBase) {
         uintptr_t gst_addr = (uintptr_t)g_MainBinaryBase + g_CachedGSTOffset;
@@ -1226,14 +1271,54 @@ static bool try_lazy_discovery(void) {
 // Resolution
 // ============================================================================
 
+/**
+ * Ensure the GlobalStringTable is resolved, RETRYING via the per-version offset
+ * table on every call until the game has actually created it. fixed_string_init
+ * runs early (GST pointer still null), so a one-shot lazy discovery would cache
+ * that failure forever. The offset-table slot is cheap to re-read, so we poll it
+ * until non-null, then probe the SubTable layout once.
+ */
+static bool g_GstOffsetsProbed = false;
+static bool ensure_gst(void) {
+    // Already have a working GST?
+    if (g_pGlobalStringTable && *g_pGlobalStringTable && g_GstOffsetsProbed) {
+        return true;
+    }
+
+    const VersionOffsets *off = offset_table_get();
+    if (off && off->gst_ptr && g_MainBinaryBase) {
+        static void *gst_slot = NULL;
+        gst_slot = (void *)((uintptr_t)g_MainBinaryBase + off->gst_ptr);
+        void *gst = NULL;
+        if (safe_read_ptr(gst_slot, &gst) && gst) {
+            g_pGlobalStringTable = (void **)gst_slot;
+            if (!g_GstOffsetsProbed) {
+                if (fixed_string_probe_offsets()) {
+                    g_GstOffsetsProbed = true;
+                    LOG_CORE_DEBUG("GST ready via offset table (retry): %p", gst);
+                } else {
+                    g_pGlobalStringTable = NULL;  // layout probe not ready yet; retry next call
+                    return false;
+                }
+            }
+            return true;
+        }
+        // GST slot still null — game hasn't created it yet; caller retries later.
+        return false;
+    }
+
+    // No offset-table entry for this version: fall back to one-shot lazy discovery.
+    return try_lazy_discovery();
+}
+
 const char *fixed_string_resolve(uint32_t index) {
     if (index == FS_NULL_INDEX) {
         return NULL;
     }
 
-    // Try lazy discovery if GST not found yet
-    if (!g_pGlobalStringTable) {
-        if (!try_lazy_discovery()) {
+    // Ensure GST is resolved (retries via offset table until the game creates it)
+    if (!g_pGlobalStringTable || !*g_pGlobalStringTable || !g_GstOffsetsProbed) {
+        if (!ensure_gst()) {
             g_FailedCount++;
             return NULL;
         }
@@ -1414,9 +1499,15 @@ static bool init_intern_function(void) {
         return false;
     }
 
-    // Calculate runtime address from Ghidra offset
+    // Remap the hardcoded 6995620 address to the running version's address.
+    uint64_t create_addr = offset_table_remap_fn(GHIDRA_FIXEDSTRING_CREATE);
+    if (!create_addr) {
+        LOG_CORE_WARN("FixedString::Create has no verified address for this version — interning disabled");
+        g_FixedStringCreate = NULL;
+        return false;
+    }
     uintptr_t runtime_addr = (uintptr_t)g_MainBinaryBase +
-                              (GHIDRA_FIXEDSTRING_CREATE - GHIDRA_BASE_ADDRESS);
+                              (create_addr - GHIDRA_BASE_ADDRESS);
 
     g_FixedStringCreate = (FixedStringCreate_t)runtime_addr;
 
@@ -1471,9 +1562,9 @@ uint32_t fixed_string_get_hash(uint32_t index) {
         return 0;
     }
 
-    // Try lazy discovery if GST not found yet
-    if (!g_pGlobalStringTable) {
-        if (!try_lazy_discovery()) {
+    // Ensure GST is resolved (retries via offset table until the game creates it)
+    if (!g_pGlobalStringTable || !*g_pGlobalStringTable || !g_GstOffsetsProbed) {
+        if (!ensure_gst()) {
             return 0;
         }
     }

--- a/src/template/template_manager.c
+++ b/src/template/template_manager.c
@@ -9,6 +9,7 @@
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
 #include "../core/version_detect.h"
+#include "../core/offset_table.h"
 #include "../strings/fixed_string.h"
 #include "../hooks/arm64_hook.h"
 #include <string.h>
@@ -207,35 +208,39 @@ static bool install_arm64_safe_hook(const char* name, void* target, void* hook_f
  * Returns true if at least one manager was captured.
  */
 static bool template_read_global_pointers(void* main_binary_base) {
-    if (!main_binary_base) return false;
+    (void)main_binary_base;  // addresses now sourced from offset_table
+
+    const VersionOffsets *off = offset_table_get();
+    if (!off) return false;
 
     int captured = 0;
+    void *mgr = NULL;
 
-    // Read GlobalTemplateManager::m_ptr
-    void** global_mgr_ptr = (void**)((uintptr_t)main_binary_base + OFFSET_GLOBAL_TEMPLATE_MANAGER_PTR);
-    void* global_mgr = *global_mgr_ptr;
-    if (global_mgr && !g_template.managers[TEMPLATE_MANAGER_GLOBAL_BANK]) {
-        g_template.managers[TEMPLATE_MANAGER_GLOBAL_BANK] = global_mgr;
-        log_message("[Template] Captured GlobalTemplateManager: %p (from global ptr)", global_mgr);
-        captured++;
+    if (off->global_template_mgr_ptr && !g_template.managers[TEMPLATE_MANAGER_GLOBAL_BANK]) {
+        void *slot = offset_table_resolve(off->global_template_mgr_ptr);
+        if (slot && safe_memory_read_pointer((mach_vm_address_t)slot, &mgr) && mgr) {
+            g_template.managers[TEMPLATE_MANAGER_GLOBAL_BANK] = mgr;
+            log_message("[Template] Captured GlobalTemplateManager: %p", mgr);
+            captured++;
+        }
     }
 
-    // Read CacheTemplateManager::m_ptr
-    void** cache_mgr_ptr = (void**)((uintptr_t)main_binary_base + OFFSET_CACHE_TEMPLATE_MANAGER_PTR);
-    void* cache_mgr = *cache_mgr_ptr;
-    if (cache_mgr && !g_template.managers[TEMPLATE_MANAGER_CACHE]) {
-        g_template.managers[TEMPLATE_MANAGER_CACHE] = cache_mgr;
-        log_message("[Template] Captured CacheTemplateManager: %p (from global ptr)", cache_mgr);
-        captured++;
+    if (off->cache_template_mgr_ptr && !g_template.managers[TEMPLATE_MANAGER_CACHE]) {
+        void *slot = offset_table_resolve(off->cache_template_mgr_ptr);
+        if (slot && safe_memory_read_pointer((mach_vm_address_t)slot, &mgr) && mgr) {
+            g_template.managers[TEMPLATE_MANAGER_CACHE] = mgr;
+            log_message("[Template] Captured CacheTemplateManager: %p", mgr);
+            captured++;
+        }
     }
 
-    // Read Level::s_CacheTemplateManager (level-local cache)
-    void** level_cache_ptr = (void**)((uintptr_t)main_binary_base + OFFSET_LEVEL_CACHE_MANAGER_PTR);
-    void* level_cache = *level_cache_ptr;
-    if (level_cache && !g_template.managers[TEMPLATE_MANAGER_LOCAL_CACHE]) {
-        g_template.managers[TEMPLATE_MANAGER_LOCAL_CACHE] = level_cache;
-        log_message("[Template] Captured Level::CacheTemplateManager: %p (from global ptr)", level_cache);
-        captured++;
+    if (off->level_cache_mgr_ptr && !g_template.managers[TEMPLATE_MANAGER_LOCAL_CACHE]) {
+        void *slot = offset_table_resolve(off->level_cache_mgr_ptr);
+        if (slot && safe_memory_read_pointer((mach_vm_address_t)slot, &mgr) && mgr) {
+            g_template.managers[TEMPLATE_MANAGER_LOCAL_CACHE] = mgr;
+            log_message("[Template] Captured Level::CacheTemplateManager: %p", mgr);
+            captured++;
+        }
     }
 
     return captured > 0;
@@ -256,10 +261,18 @@ bool template_install_hooks(void* main_binary_base) {
 
     g_template.main_binary_base = main_binary_base;
 
+    const VersionOffsets *off = offset_table_get();
     log_message("[Template] Using global pointer read approach (no hooks needed)");
-    log_message("[Template]   GlobalTemplateManager::m_ptr at offset 0x%x", OFFSET_GLOBAL_TEMPLATE_MANAGER_PTR);
-    log_message("[Template]   CacheTemplateManager::m_ptr at offset 0x%x", OFFSET_CACHE_TEMPLATE_MANAGER_PTR);
-    log_message("[Template]   Level::s_CacheTemplateManager at offset 0x%x", OFFSET_LEVEL_CACHE_MANAGER_PTR);
+    if (off) {
+        log_message("[Template]   GlobalTemplateManager::m_ptr offset 0x%llx",
+                    (unsigned long long)off->global_template_mgr_ptr);
+        log_message("[Template]   CacheTemplateManager::m_ptr offset 0x%llx",
+                    (unsigned long long)off->cache_template_mgr_ptr);
+        log_message("[Template]   Level::s_CacheTemplateManager offset 0x%llx",
+                    (unsigned long long)off->level_cache_mgr_ptr);
+    } else {
+        log_message("[Template]   No offset table entry for this version — pointers may not resolve");
+    }
 
     // Try to read managers now (may be NULL if called early)
     bool captured = template_read_global_pointers(main_binary_base);
@@ -437,23 +450,17 @@ bool template_manager_init(void* main_binary_base) {
     memset(g_template.managers, 0, sizeof(g_template.managers));
     memset(g_template.template_counts, -1, sizeof(g_template.template_counts));
 
-    // Install auto-capture hooks. These are inline Dobby CODE hooks at hardcoded
-    // main-binary offsets, valid only for the exact verified build. On a version
-    // mismatch the targets are stale and patching them corrupts unrelated game code
-    // (Issue #78 — crashed esv::hotbar::System on new-game load). Gate on an EXACT
-    // version match, like the functor and staticdata hooks. The lazy global-pointer
-    // reads (template_read_global_pointers) are pure data reads and stay active, so
-    // Ext.Template still degrades gracefully rather than crashing.
-    if (main_binary_base && version_detect_matches()) {
+    // template_install_hooks reads global singleton pointers from the offset table.
+    // It is safe to call whenever a table entry exists (no code patching involved).
+    if (main_binary_base && offset_table_get()) {
         bool hooks_ok = template_install_hooks(main_binary_base);
         if (hooks_ok) {
-            log_message("[Template] Auto-capture hooks installed (waiting for game activity)");
+            log_message("[Template] Template pointers initialized");
         } else {
-            log_message("[Template] Failed to install auto-capture hooks, falling back to Frida capture");
+            log_message("[Template] Template pointers not yet available, will retry on first access");
         }
     } else if (main_binary_base) {
-        log_message("[Template] Auto-capture hooks SKIPPED (game version mismatch — "
-                    "code patching unsafe; using global-pointer reads only)");
+        log_message("[Template] Skipping pointer reads (no offset table entry for this version)");
     }
 
     g_template.initialized = true;

--- a/src/template/template_manager.c
+++ b/src/template/template_manager.c
@@ -8,6 +8,7 @@
 #include "template_manager.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/version_detect.h"
 #include "../strings/fixed_string.h"
 #include "../hooks/arm64_hook.h"
 #include <string.h>
@@ -436,14 +437,23 @@ bool template_manager_init(void* main_binary_base) {
     memset(g_template.managers, 0, sizeof(g_template.managers));
     memset(g_template.template_counts, -1, sizeof(g_template.template_counts));
 
-    // Install auto-capture hooks
-    if (main_binary_base) {
+    // Install auto-capture hooks. These are inline Dobby CODE hooks at hardcoded
+    // main-binary offsets, valid only for the exact verified build. On a version
+    // mismatch the targets are stale and patching them corrupts unrelated game code
+    // (Issue #78 — crashed esv::hotbar::System on new-game load). Gate on an EXACT
+    // version match, like the functor and staticdata hooks. The lazy global-pointer
+    // reads (template_read_global_pointers) are pure data reads and stay active, so
+    // Ext.Template still degrades gracefully rather than crashing.
+    if (main_binary_base && version_detect_matches()) {
         bool hooks_ok = template_install_hooks(main_binary_base);
         if (hooks_ok) {
             log_message("[Template] Auto-capture hooks installed (waiting for game activity)");
         } else {
             log_message("[Template] Failed to install auto-capture hooks, falling back to Frida capture");
         }
+    } else if (main_binary_base) {
+        log_message("[Template] Auto-capture hooks SKIPPED (game version mismatch — "
+                    "code patching unsafe; using global-pointer reads only)");
     }
 
     g_template.initialized = true;

--- a/tools/offset_manifest.json
+++ b/tools/offset_manifest.json
@@ -1,0 +1,97 @@
+{
+  "_about": [
+    "Recipe for porting BG3SE-macOS address tables to a new game version.",
+    "Every per-version address the code needs is listed here with how to resolve it.",
+    "The macOS BG3 binary keeps its symbol table, so most entries resolve via `nm`.",
+    "Run: PYTHONPATH=tools python3 -m tools.port_offsets resolve   (see docs/PORTING.md)",
+    "",
+    "Resolution methods:",
+    "  symbol      -> nm the demangled `symbol`; the address IS the result.",
+    "  data_shift  -> not exported; result = (baseline_ghidra + data_shift), where",
+    "                 data_shift is derived once from `data_shift_anchor` below.",
+    "  constant    -> a __TEXT/data address that does NOT change between versions",
+    "                 (verify it still resolves to the same symbol; warn if not).",
+    "  struct_offset -> a field offset WITHIN an object. Stable across minor patches.",
+    "                 Carried as-is; only changes if Larian restructures the class",
+    "                 (then it needs Ghidra/runtime re-discovery -- the tool flags it).",
+    "All `baseline` values are full Ghidra addresses for 4.1.1.6995620 (the verified base)."
+  ],
+
+  "baseline_version": "4.1.1.6995620",
+
+  "data_shift_anchor": {
+    "_note": "Derives the uniform __DATA shift = nm(symbol) - baseline. For 7209685 this is +0x8000. Pick an exported global whose 6995620 address is known.",
+    "symbol": "ls::TypeId<eoc::FeatManager, ls::ImmutableDataHeadmaster>::m_TypeIndex",
+    "baseline": "0x1088efd00"
+  },
+
+  "offset_table_functions": [
+    {"field": "fn_feat_getfeats",      "baseline": "0x101b752b4", "symbol": "eoc::FeatManager::GetFeats() const"},
+    {"field": "fn_getallfeats",        "baseline": "0x10120b3e8", "symbol": "eoc::character_creation::GetAllFeats(eoc::character_creation::Environment const&)"},
+    {"field": "fn_get_background",     "baseline": "0x102994834", "symbol": "eoc::BackgroundManager const* ls::ImmutableDataHeadmaster::Get<eoc::BackgroundManager>() const"},
+    {"field": "fn_get_origin",         "baseline": "0x10341c42c", "symbol": "eoc::OriginManager const* ls::ImmutableDataHeadmaster::Get<eoc::OriginManager>() const"},
+    {"field": "fn_get_class",          "baseline": "0x10262f184", "symbol": "eoc::ClassDescriptions const* ls::ImmutableDataHeadmaster::Get<eoc::ClassDescriptions>() const"},
+    {"field": "fn_get_progression",    "baseline": "0x103697f0c", "symbol": "eoc::ProgressionManager const* ls::ImmutableDataHeadmaster::Get<eoc::ProgressionManager>() const"},
+    {"field": "fn_get_actionresource", "baseline": "0x1011a4494", "symbol": "eoc::ActionResourceTypes const* ls::ImmutableDataHeadmaster::Get<eoc::ActionResourceTypes>() const"},
+    {"field": "fn_get_template_raw",   "baseline": "0x105f96304", "symbol": "ls::GlobalTemplateManager::GetTemplateRaw(ls::FixedString const&) const"},
+    {"field": "fn_cache_template",     "baseline": "0x105d31ce4", "symbol": "ls::CacheTemplateManagerBase::CacheTemplate(ls::GameObjectTemplate const*, ls::FixedString const&, ls::FixedString const&)"},
+    {"field": "fn_try_get_uuid_mapping","baseline": "0x1010dc924", "symbol": "ls::Result<ecs::_private::EntityViewFinder<ecs::_private::QueryViewFinder<ecs::query::alive::Spec<ls::TypeList<ls::uuid::ToHandleMappingComponent const>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ecs::QueryTypePersistentTag, ecs::QueryTypeAliveTag>>::type>::type, ls::Error> ecs::legacy::Helper::TryGetSingleton<ecs::query::alive::Spec<ls::TypeList<ls::uuid::ToHandleMappingComponent const>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ecs::QueryTypePersistentTag, ecs::QueryTypeAliveTag>>(ecs::EntityWorld&)"},
+    {"field": "fn_storage_tryget",     "baseline": "0x10636b27c", "symbol": "ecs::EntityStorageContainer::TryGet(ls::ID<ecs::EntityHandleTraits>)"},
+    {"field": "fn_spell_proto_init",   "baseline": "0x101f72754", "symbol": "eoc::SpellPrototype::Init(ls::FixedString const&)"}
+  ],
+
+  "remap_functions": [
+    {"name": "FixedString::Create",        "baseline": "0x1064b9ebc", "symbol": "ls::FixedString::Create(char const*, int)"},
+    {"name": "ResourceContainer::GetResource","baseline": "0x1060cc608", "symbol": "ls::ResourceContainer::GetResource(ls::EResourceType, ls::FixedString const&) const"},
+    {"name": "ExecuteStatsFunctor",        "baseline": "0x105783a38", "symbol": "ExecuteStatsFunctor(eoc::StatsFunctorBase const*, unsigned long, esv::functor::AttackTargetContextData&)"},
+    {"name": "ExecuteFunctors<AttackTarget>","baseline": "0x105787918", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::AttackTargetContextData&)"},
+    {"name": "ExecuteFunctors<AttackPosition>","baseline": "0x105787c6c","symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::AttackPositionContextData&)"},
+    {"name": "ExecuteFunctors<Move>",      "baseline": "0x10578975c", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::MoveContextData&)"},
+    {"name": "ExecuteFunctors<Target>",    "baseline": "0x10578a918", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::TargetContextData&)"},
+    {"name": "ExecuteFunctors<NearbyAttacked>","baseline": "0x10578e4d8","symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::NearbyAttackedContextData&)"},
+    {"name": "ExecuteFunctors<NearbyAttacking>","baseline": "0x10578fba8","symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::NearbyAttackingContextData&)"},
+    {"name": "ExecuteFunctors<Equip>",     "baseline": "0x105790a28", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::EquipContextData&)"},
+    {"name": "ExecuteFunctors<Source>",    "baseline": "0x105792a90", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::SourceContextData&)"},
+    {"name": "ExecuteFunctors<Interrupt>", "baseline": "0x1057965e4", "symbol": "esv::functor::ExecuteStatsFunctors(ecs::EntityWorld&, eoc::StatsFunctorList const*, esv::functor::InterruptContextData&)"},
+    {"name": "TranslatedStringRepository::TryGet","baseline": "0x106534d54","symbol": "ls::TranslatedStringRepository::TryGet(ls::RuntimeStringHandle const&, ls::identity::EIdentity, ls::identity::EIdentity) const"},
+    {"name": "TranslatedStringRepository::Get","baseline": "0x106535148","symbol": "ls::TranslatedStringRepository::Get(ls::RuntimeStringHandle const&, ls::identity::EIdentity, ls::identity::EIdentity) const"},
+    {"name": "TranslatedStringRepository::AddTranslatedString","baseline": "0x106532590","symbol": "ls::TranslatedStringRepository::AddTranslatedString(ls::RuntimeStringHandle, ls::_StringView<char>, ls::TranslatedMapRepo<ls::RuntimeStringNoVersionHashOps>*, ls::EnumFlags<ls::EAddFlags>)"},
+    {"name": "MessageFactory::GetFreeMessage","baseline": "0x1063d5998","symbol": "net::MessageFactory::GetFreeMessage(int)"},
+    {"name": "STDString::STDString(char const*)","baseline": "0x10651fb60","symbol": "ls::STDString::STDString(char const*)"}
+  ],
+
+  "constant_functions": [
+    {"name": "BinkManager::LoadVideo", "baseline": "0x10390b6cc", "symbol": "bik::BinkManager::LoadVideo(ls::Path const&)", "_note": "unchanged 6995620 -> 7209685; verify it still maps to this symbol"}
+  ],
+
+  "_data_singletons_note": "baseline = offset from binary base (the value stored in offset_table.c, i.e. Ghidra addr - 0x100000000). result = baseline + data_shift.",
+  "data_singletons": [
+    {"field": "eocserver_ptr",           "baseline": "0x0898e8b8", "method": "data_shift", "note": "esv::EocServer::m_ptr (not exported)"},
+    {"field": "eocclient_ptr",           "baseline": "0x0898c968", "method": "data_shift", "note": "ecl::EocClient::m_ptr (not exported)"},
+    {"field": "spell_proto_mgr_ptr",     "baseline": "0x089bac80", "method": "data_shift", "note": "SpellPrototypeManager::m_ptr (not exported)"},
+    {"field": "rpgstats_ptr",            "baseline": "0x089c5730", "method": "data_shift", "note": "RPGStats::m_ptr (not exported)"},
+    {"field": "resource_mgr_ptr",        "baseline": "0x08a8f070", "method": "data_shift", "note": "ResourceManager::m_ptr (not exported)"},
+    {"field": "level_mgr_ptr",           "baseline": "0x08a3be40", "method": "data_shift", "note": "LevelManager::m_ptr (not exported)"},
+    {"field": "global_template_mgr_ptr", "baseline": "0x08a88508", "method": "data_shift", "note": "ls::GlobalTemplateManager::m_ptr (not exported)"},
+    {"field": "cache_template_mgr_ptr",  "baseline": "0x08a309a8", "method": "data_shift", "note": "CacheTemplateManager::m_ptr (not exported)"},
+    {"field": "level_cache_mgr_ptr",     "baseline": "0x08a735d8", "method": "data_shift", "note": "Level::s_CacheTemplateManager (not exported)"},
+    {"field": "staticdata_mstate_ptr",   "baseline": "0x083c4a68", "method": "data_shift", "note": "PTR to ImmutableDataHeadmaster TypeContext m_State (not exported)"},
+    {"field": "gst_ptr",                 "baseline": "0x08aeccd8", "method": "data_shift", "note": "ls::gGlobalStringTable subtable base ptr (verify via ls::gst::Get disasm)"}
+  ],
+
+  "exported_data": [
+    {"name": "TranslatedStringRepository::m_ptr", "baseline": "0x108aed088", "symbol": "ls::TranslatedStringRepository::m_ptr", "consumer": "localization.c LOCA_REPO_OFFSET", "_note": "exported 'b' symbol; also equals data_shift result -- good cross-check"}
+  ],
+
+  "struct_offsets": [
+    {"name": "EocServer -> EntityWorld",          "value": "0x288",  "where": "entity_system.c OFFSET_ENTITYWORLD_IN_EOCSERVER", "verify_via": "esv::EocServer::StartUp disasm: ldr xN,[this,#0x288]"},
+    {"name": "EntityWorld -> StorageContainer",   "value": "0x2d0",  "where": "component_templates.h ENTITYWORLD_STORAGE_OFFSET"},
+    {"name": "EntityWorld -> ImmediateWorldCache","value": "0x3f0",  "where": "component_templates.h ENTITYWORLD_CACHE_OFFSET"},
+    {"name": "RPGStats -> FixedStrings pool",     "value": "0x348",  "where": "ghidra/offsets/STATS.md"},
+    {"name": "RefMap capacity",                   "value": "0x10",   "where": "prototype_managers.c REFMAP_OFFSET_CAPACITY"},
+    {"name": "RefMap keys array",                 "value": "0x28",   "where": "prototype_managers.c REFMAP_OFFSET_KEYS"},
+    {"name": "RefMap values array",               "value": "0x38",   "where": "prototype_managers.c REFMAP_OFFSET_VALUES"},
+    {"name": "Stat object -> name FixedString",   "value": "0x20",   "where": "stats_manager.c STATS_OBJECT_OFFSET_NAME"},
+    {"name": "GST subtable stride",               "value": "0x1200", "where": "fixed_string.c (ls::gst::Get: umaddl ... #0x1200)"}
+  ]
+}

--- a/tools/port_offsets.py
+++ b/tools/port_offsets.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+port_offsets.py — resolve BG3SE-macOS per-version addresses against a BG3 binary.
+
+The macOS BG3 binary keeps its symbol table, so almost every per-version address
+is a `nm` lookup. This tool reads tools/offset_manifest.json (the recipe) and, for
+a target binary, resolves every address and emits ready-to-paste offset_table.c
+content. Anything it can't resolve is flagged — that's your signal that a struct
+changed and you need Ghidra/runtime probing for that one item.
+
+Usage:
+  python3 tools/port_offsets.py resolve [--binary PATH] [--emit]
+  python3 tools/port_offsets.py verify  [--binary PATH]   # diff vs offset_table.c
+
+See docs/PORTING.md.
+"""
+import argparse, json, os, re, subprocess, sys, tempfile, plistlib
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+MANIFEST = os.path.join(HERE, "offset_manifest.json")
+OFFSET_TABLE_C = os.path.join(REPO, "src", "core", "offset_table.c")
+GHIDRA_BASE = 0x100000000
+
+DEFAULT_BINARY = os.path.expanduser(
+    "~/Library/Application Support/Steam/steamapps/common/"
+    "Baldurs Gate 3/Baldur's Gate 3.app/Contents/MacOS/Baldur's Gate 3"
+)
+
+# ----------------------------------------------------------------------------
+# Binary + symbol handling
+# ----------------------------------------------------------------------------
+
+def thin_arm64(binary):
+    """Return a path to an arm64 thin slice (extracting if the binary is fat)."""
+    archs = subprocess.run(["lipo", "-archs", binary], capture_output=True, text=True)
+    if archs.returncode != 0:
+        # not a fat binary / lipo failed — assume it's already thin
+        return binary
+    if "arm64" not in archs.stdout.split():
+        sys.exit(f"error: {binary} has no arm64 slice (archs: {archs.stdout.strip()})")
+    if archs.stdout.split() == ["arm64"]:
+        return binary
+    out = os.path.join(tempfile.gettempdir(), "bg3_arm64_thin_port")
+    subprocess.run(["lipo", "-thin", "arm64", binary, "-output", out], check=True)
+    return out
+
+def norm(s):
+    """Normalize a C++ signature for matching (whitespace-insensitive)."""
+    return re.sub(r"\s+", "", s)
+
+def build_symbol_map(thin):
+    """{normalized_demangled_name: set(addresses)} from nm + c++filt."""
+    raw = subprocess.run(["nm", thin], capture_output=True, text=True).stdout
+    dem = subprocess.run(["c++filt"], input=raw, capture_output=True, text=True).stdout
+    table = {}
+    for line in dem.splitlines():
+        parts = line.split(" ", 2)
+        if len(parts) < 3:
+            continue
+        addr, typ, name = parts
+        if not re.fullmatch(r"[0-9a-fA-F]+", addr):
+            continue  # undefined symbol (no address)
+        table.setdefault(norm(name), set()).add(int(addr, 16))
+    return table
+
+def lookup(symtab, symbol):
+    """Return (addr, note). note flags ambiguity/missing."""
+    addrs = symtab.get(norm(symbol))
+    if not addrs:
+        return None, "NOT FOUND"
+    if len(addrs) > 1:
+        return sorted(addrs)[0], f"AMBIGUOUS ({len(addrs)} matches; took lowest)"
+    return next(iter(addrs)), ""
+
+def detect_version(binary):
+    info = os.path.join(os.path.dirname(os.path.dirname(binary)), "Info.plist")
+    try:
+        with open(info, "rb") as f:
+            return plistlib.load(f).get("CFBundleShortVersionString")
+    except Exception:
+        return None
+
+def hx(v):
+    return f"0x{v:08x}"
+
+# ----------------------------------------------------------------------------
+# Resolution
+# ----------------------------------------------------------------------------
+
+def resolve(manifest, symtab):
+    """Return a dict of resolved values + a list of (level, message) issues."""
+    issues = []
+    out = {"fn": {}, "data": {}, "remap": [], "exported": {}, "constants": [], "struct": []}
+
+    # 1. derive the __DATA shift from the anchor
+    anchor = manifest["data_shift_anchor"]
+    a_addr, a_note = lookup(symtab, anchor["symbol"])
+    if a_addr is None:
+        issues.append(("FATAL", f"data_shift anchor '{anchor['symbol']}' not found — "
+                                "cannot derive __DATA shift. Pick another exported anchor."))
+        return out, issues
+    shift = a_addr - int(anchor["baseline"], 16)
+    out["data_shift"] = shift
+    issues.append(("INFO", f"__DATA shift derived from anchor: {hx(shift)} "
+                           f"(anchor {anchor['symbol'].split('(')[0]} {hx(int(anchor['baseline'],16))} -> 0x{a_addr:x})"))
+
+    # 2. offset_table functions (symbol)
+    for e in manifest["offset_table_functions"]:
+        addr, note = lookup(symtab, e["symbol"])
+        if addr is None:
+            issues.append(("ERROR", f"offset_table.{e['field']}: symbol not found ({e['symbol'][:60]}...)"))
+        else:
+            out["fn"][e["field"]] = addr - GHIDRA_BASE
+            if note:
+                issues.append(("WARN", f"offset_table.{e['field']}: {note}"))
+
+    # 3. data singletons (data_shift)
+    for e in manifest["data_singletons"]:
+        out["data"][e["field"]] = int(e["baseline"], 16) + shift
+
+    # 4. exported data (symbol; cross-check against data_shift where applicable)
+    for e in manifest["exported_data"]:
+        addr, note = lookup(symtab, e["symbol"])
+        if addr is None:
+            issues.append(("ERROR", f"exported_data {e['name']}: symbol not found"))
+        else:
+            out["exported"][e["name"]] = addr
+            base = e.get("baseline")
+            if base and (addr - int(base, 16)) != shift:
+                issues.append(("WARN", f"exported_data {e['name']}: shift {hx(addr-int(base,16))} "
+                                       f"!= __DATA shift {hx(shift)} (segment may differ)"))
+
+    # 5. remap functions (symbol)
+    for e in manifest["remap_functions"]:
+        addr, note = lookup(symtab, e["symbol"])
+        if addr is None:
+            issues.append(("ERROR", f"remap {e['name']}: symbol not found ({e['symbol'][:60]}...)"))
+        else:
+            out["remap"].append((int(e["baseline"], 16), addr, e["name"]))
+            if note:
+                issues.append(("WARN", f"remap {e['name']}: {note}"))
+
+    # 6. constant functions (verify unchanged)
+    for e in manifest.get("constant_functions", []):
+        addr, note = lookup(symtab, e["symbol"])
+        base = int(e["baseline"], 16)
+        if addr is None:
+            issues.append(("WARN", f"constant {e['name']}: symbol not found — cannot verify it is unchanged"))
+        elif addr != base:
+            issues.append(("ERROR", f"constant {e['name']}: CHANGED {hx(base)} -> 0x{addr:x} "
+                                    "— it is NOT constant for this version; promote it to remap_functions"))
+        out["constants"].append((e["name"], base, addr))
+
+    # 7. struct offsets — carried, not re-resolved (documented)
+    out["struct"] = manifest.get("struct_offsets", [])
+    return out, issues
+
+# ----------------------------------------------------------------------------
+# Output
+# ----------------------------------------------------------------------------
+
+def emit_c(out, version):
+    L = []
+    L.append(f"    /* ---- generated by tools/port_offsets.py for {version} ---- */")
+    L.append("    {")
+    L.append(f'        .version                 = "{version}",')
+    L.append("")
+    L.append("        /* Singleton pointer globals (data_shift = %s) */" % hx(out["data_shift"]))
+    for field, val in out["data"].items():
+        L.append(f"        .{field:<24} = {hx(val)},")
+    L.append("")
+    L.append("        /* Function offsets (symbol-resolved) */")
+    for field, val in out["fn"].items():
+        L.append(f"        .{field:<24} = {hx(val)},")
+    L.append(f"        .component_data_shift    = {hx(out['data_shift'])},")
+    L.append("    },")
+    L.append("")
+    L.append(f"    /* g_fn_remap_<ver> entries for {version}: */")
+    for base, new, name in out["remap"]:
+        L.append(f"    {{ 0x{base:09x}, 0x{new:09x} }},  // {name}")
+    return "\n".join(L)
+
+# ----------------------------------------------------------------------------
+# verify: compare generated values against what's in offset_table.c
+# ----------------------------------------------------------------------------
+
+def parse_offset_table_c(version):
+    """Extract the {.field = 0x..} block for `version` and the remap pairs."""
+    txt = open(OFFSET_TABLE_C).read()
+    fields = {}
+    # find the struct entry for this version
+    m = re.search(r'\.version\s*=\s*"' + re.escape(version) + r'"(.*?)\n\s*\},', txt, re.S)
+    if m:
+        for fm in re.finditer(r'\.(\w+)\s*=\s*(0x[0-9a-fA-F]+)', m.group(1)):
+            fields[fm.group(1)] = int(fm.group(2), 16)
+    remap = []
+    rm = re.search(r'g_fn_remap_\w+\[\]\s*=\s*\{(.*?)\n\};', txt, re.S)
+    if rm:
+        for pm in re.finditer(r'\{\s*(0x[0-9a-fA-F]+)\s*,\s*(0x[0-9a-fA-F]+)\s*\}', rm.group(1)):
+            remap.append((int(pm.group(1), 16), int(pm.group(2), 16)))
+    return fields, remap
+
+def do_verify(out, version):
+    fields, remap = parse_offset_table_c(version)
+    if not fields:
+        print(f"  (no '{version}' entry in offset_table.c to verify against)")
+        return 0
+    mism = 0
+    gen = {**out["data"], **out["fn"], "component_data_shift": out["data_shift"]}
+    for f, v in gen.items():
+        cur = fields.get(f)
+        if cur is None:
+            print(f"  MISSING in offset_table.c: .{f} (generated {hx(v)})"); mism += 1
+        elif cur != v:
+            print(f"  MISMATCH .{f}: table={hx(cur)} generated={hx(v)}"); mism += 1
+    gen_remap = {b: n for b, n, _ in out["remap"]}
+    cur_remap = dict(remap)
+    for b, n in gen_remap.items():
+        if cur_remap.get(b) != n:
+            print(f"  REMAP MISMATCH 0x{b:x}: table={cur_remap.get(b) and hex(cur_remap[b])} generated=0x{n:x}"); mism += 1
+    if mism == 0:
+        print(f"  ✓ all {len(gen)} fields + {len(gen_remap)} remap entries match offset_table.c")
+    return mism
+
+# ----------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("cmd", choices=["resolve", "verify"])
+    ap.add_argument("--binary", default=DEFAULT_BINARY, help="path to the BG3 Mach-O binary")
+    ap.add_argument("--version", help="override detected version label")
+    ap.add_argument("--emit", action="store_true", help="(resolve) print copy-pasteable offset_table.c content")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.binary):
+        sys.exit(f"error: binary not found: {args.binary}\n  pass --binary PATH")
+    manifest = json.load(open(MANIFEST))
+    version = args.version or detect_version(args.binary) or "UNKNOWN"
+
+    print(f"binary : {args.binary}")
+    print(f"version: {version}")
+    print("indexing symbols (nm + c++filt)...")
+    symtab = build_symbol_map(thin_arm64(args.binary))
+    print(f"  {len(symtab)} symbols\n")
+
+    out, issues = resolve(manifest, symtab)
+
+    rank = {"FATAL": 0, "ERROR": 1, "WARN": 2, "INFO": 3}
+    for lvl, msg in sorted(issues, key=lambda i: rank.get(i[0], 9)):
+        print(f"[{lvl}] {msg}")
+    errs = sum(1 for l, _ in issues if l in ("FATAL", "ERROR"))
+    print()
+
+    if args.cmd == "verify":
+        mism = do_verify(out, version)
+        sys.exit(1 if (mism or errs) else 0)
+
+    # resolve
+    nres = len(out["fn"]) + len(out["data"]) + len(out["remap"]) + len(out["exported"])
+    print(f"resolved {nres} addresses; {len(out['struct'])} struct offsets carried (stable).")
+    if args.emit:
+        print("\n" + "=" * 70)
+        print(emit_c(out, version))
+        print("=" * 70)
+    else:
+        print("re-run with --emit to print copy-pasteable offset_table.c content.")
+    sys.exit(1 if errs else 0)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

The Issue #78 hotbar crash on new-game load returned on BG3 4.1.1.7209685.

version_detect_addresses_safe()'s sentinel probes (added in b5dd64d) pass on this build, which re-enables staticdata_manager_init() and template_manager_init(). Both install inline DobbyHook patches at hardcoded main-binary offsets that are only valid for the verified build (4.1.1.6995620). On a mismatch those targets are stale, so the patch overwrites whatever code now lives there, corrupting a function that esv::hotbar::System::FinalizeAddSlot later calls — ServerWorker then jumps to a heap address and SIGBUSes during session load.

Gate both managers' code-patching on version_detect_matches() (exact match) — the same policy functor_hooks_init() already uses. Pure data reads stay under the sentinel gate, so the managers degrade gracefully (0 captured managers) instead of corrupting the game.

Verified on 7209685: hooks now report SKIPPED, session reaches Running, and a new game loads past 83% without crashing.