### PR TITLE
Integrate community PRs #91 (offset table) + #93 (Osiris DB, mod runtime)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ add_library(bg3se SHARED
     src/core/safe_memory.c
     src/core/crashlog.c
     src/core/version_detect.c
+    src/core/offset_table.c
     src/core/mach_exception.c
     src/core/mach_exc_stubs/mach_excServer.c
     src/lua/lua_gate.c

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,45 @@ Each entry includes:
 
 ---
 
+## [Unreleased] — Community PR integration: offset-table architecture + Osiris DB access + mod runtime
+
+**Category:** Community contributions | **Branch:** `integration/community-prs` | **Issues:** PR #91, PR #93
+
+Integration of the two community pull requests, reconciled with the current
+codebase rather than merged verbatim (both predated the v0.38.x mod-detection
+and game-path work). Credit: **@mikowals** (PR #91 — per-version offset table,
+build 7209685 support, `tools/port_offsets.py`) and **@marcus-sa** (PR #93 —
+Osiris database RE + Facts reader, per-mod `_ENV` sandbox, module cache,
+GameStateChanged EnumValues, Ext.IO VFS semantics).
+
+### Added
+- **Per-version offset table** (`src/core/offset_table.c/h`) — every
+  game-version-dependent address lives in one audited table; unknown versions
+  fail closed. `tools/port_offsets.py` semi-automates migration to new builds
+  (PR #91, mikowals).
+- **Osi.DB_* real database reads** — name-index walk of `COsiFunctionMan`
+  discovers Osiris databases (invisible to the id-probe); `Osi.DB_X:Get(...)`
+  walks the CReteDBase Facts list directly with typed filters, Windows-style
+  (PR #93, marcus-sa; RE documented in `ghidra/offsets/OSIRIS_DATABASES.md`).
+- **Signature-typed Osi dispatch** — parameter types/directions read from the
+  game's OsirisInterface function defs (offset-table gated); pure test queries
+  return integer 0/1, out-param queries return values or nil (Windows parity).
+- **Per-mod `_ENV` sandbox** — mod chunks execute inside `Mods.<ModTable>`
+  with `__index = _G` fallback and mod-local `_G`/`ModuleUUID`; registry-backed
+  module cache; bare `require()` resolves mod-relative then falls through to
+  stock Lua require (PR #93, marcus-sa).
+- **GameStateChanged EnumValues** — `ClientGameState`/`ServerGameState`
+  registered in `Ext.Enums`; event states and `Ext.Utils.GetGameState()` return
+  EnumValue userdata comparable with `==` (MCM's init gate).
+
+### Fixed
+- Hardening pass from a four-agent review (two Codex, two Claude) over the
+  integration: CTuple small-object storage, stale-registry re-walk on save
+  load, param-def validation, engine-string safe reads, Ext.IO path
+  containment, PAK entry bounds validation, per-mod loader state clearing.
+
+---
+
 ## [v0.38.1] - 2026-07-29 — Community issue triage: mod detection + game-path discovery
 
 **Category:** Compatibility fixes | **Parity:** ~94.7% | **Issues:** #87, #81, #90, #86, #84, #82, #88

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -1,0 +1,123 @@
+# Porting BG3SE-macOS to a new game version
+
+When Larian patches Baldur's Gate 3, the macOS Script Extender breaks because the
+game's functions and global variables move to new addresses. This guide + the
+`tools/port_offsets.py` tool turn that re-port from a multi-hour reverse‑engineering
+session into, usually, **run a script and paste the output**.
+
+## Why this is easy on macOS (and hard on Windows)
+
+The macOS BG3 binary **ships with its symbol table** — ~725,000 named symbols.
+So almost every address the extender needs can be found by name with `nm`, no
+Ghidra required. (Norbyte's Windows extender needs heavy pattern‑scanning because
+the Windows binary is stripped.)
+
+There are two kinds of address, and only one kind changes per patch:
+
+| Kind | Example | Changes per patch? | How to find |
+|------|---------|--------------------|-------------|
+| **Absolute address** | `SpellPrototype::Init` entry point; `RPGStats::m_ptr` slot | **Yes** | `nm` by symbol, or a uniform `__DATA` shift |
+| **Struct field offset** | EocServer → EntityWorld is at `+0x288` | No (until a class is restructured) | One‑time Ghidra/runtime; carried forward |
+
+`tools/offset_manifest.json` lists every address in both categories with its
+symbol and resolution method. It is the source of truth — the recipe.
+
+## TL;DR — re-port to your installed version
+
+```bash
+# 1. See what resolves and what (if anything) needs attention:
+python3 tools/port_offsets.py resolve
+
+# 2. Print copy-pasteable C for src/core/offset_table.c:
+python3 tools/port_offsets.py resolve --emit
+
+# 3. Paste the generated struct entry into g_offset_table[] and the remap
+#    rows into g_fn_remap_<yourversion>[] (add that array + a branch in
+#    offset_table_remap_fn for the new version string), then:
+cd build && cmake --build .
+
+# 4. Launch, load a save, and run the regression suite:
+#    !test        (in the SE console)  -> expect 109/109
+#    !test_ingame
+```
+
+The tool auto-detects your version from the app's `Info.plist`. Override with
+`--binary PATH` or `--version X.Y.Z` if needed.
+
+## Verifying the tool against a known-good version
+
+```bash
+python3 tools/port_offsets.py verify
+```
+
+This resolves every address against your binary and **diffs against the values
+already in `offset_table.c`**. On the version the table was built for it prints
+`✓ all N fields + M remap entries match`. That's the proof the automation
+reproduces hand-done work before you trust it on a new version.
+
+## Reading the output / fixing flags
+
+The resolver classifies every item:
+
+- `[INFO] __DATA shift derived ...` — the uniform shift for non-exported globals
+  (e.g. `RPGStats::m_ptr`), computed from the `data_shift_anchor`. Sanity-check it
+  looks like a small, plausible delta.
+- `[WARN] ... AMBIGUOUS` — the symbol matched more than one address (e.g. const
+  vs non-const overload). The tool takes the lowest; **make the manifest `symbol`
+  more specific** (full signature) so it's unique, then re-run.
+- `[ERROR] ... symbol not found` — the function was renamed/inlined, or the
+  signature drifted. Open the binary's symbols (`nm BINARY | c++filt | grep Name`)
+  and update the manifest `symbol`. If it's genuinely gone, that feature needs
+  rework.
+- `[ERROR] constant ... CHANGED` — an address we assumed was stable moved. Move
+  that entry from `constant_functions` to `remap_functions`.
+- `[WARN] exported_data ... shift != __DATA shift` — that global lives in a
+  segment that shifted differently. Resolve it by its own symbol (it already is)
+  and don't rely on the uniform shift for it.
+
+Anything not flagged resolved cleanly.
+
+## When you DO need Ghidra (struct offsets)
+
+`struct_offsets` in the manifest are field offsets *inside* objects (e.g.
+`EntityWorld -> StorageContainer` at `+0x2d0`). They're stable across minor
+patches and the tool just carries them. They only change if Larian restructures
+a class — symptoms are a crash *inside* a game function after the entry address
+is already correct, or a structural read returning garbage. To re-find one:
+
+- Each entry has a `verify_via` / `where` pointing at how it was originally found
+  (often a one-line disassembly check, e.g. `EocServer::StartUp` does
+  `ldr xN,[this,#0x288]`). `otool -tV` the named function and read the offset.
+- Or probe at runtime with `Ext.Debug.ProbeStruct` / `ReadPtr` against a live
+  object (see `agent_docs/development.md`).
+
+Update the `value` in the manifest and the matching `#define` in the code.
+
+## Adding a brand-new address to the recipe
+
+If you wire a new game function/global into the extender, add it to the manifest
+so future ports resolve it automatically:
+
+- A called game function → `remap_functions` (or `offset_table_functions` if it
+  has a dedicated `VersionOffsets` field). Give the exact demangled `symbol` and
+  its current-version `baseline` address.
+- A non-exported singleton pointer → `data_singletons` with its `baseline` offset.
+- A field offset inside an object → `struct_offsets`.
+
+Find the exact symbol string with:
+
+```bash
+nm "$BG3_BINARY" | c++filt | grep "YourFunctionName"
+```
+
+Use whatever `c++filt` prints, verbatim, as the manifest `symbol` (whitespace is
+normalized during matching).
+
+## How the remap table works (background)
+
+Many subsystems hold a hardcoded *baseline* (6995620) game-function address and
+call it as a function pointer. `offset_table_remap_fn(addr)` (in `offset_table.c`)
+returns the correct address for the running version, or **0 if it isn't in the
+remap table — in which case the caller skips that feature instead of jumping to a
+stale address and crashing.** So even an un-ported function degrades gracefully.
+The tool generates the `g_fn_remap_<version>[]` rows for you.

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -16,7 +16,7 @@ There are two kinds of address, and only one kind changes per patch:
 
 | Kind | Example | Changes per patch? | How to find |
 |------|---------|--------------------|-------------|
-| **Absolute address** | `SpellPrototype::Init` entry point; `RPGStats::m_ptr` slot | **Yes** | `nm` by symbol, or a uniform `__DATA` shift |
+| **Absolute address** | `SpellPrototype::Init` entry point; `RPGStats::m_ptr` slot | **Yes** | `nm` by symbol (plain `nm` sees local symbols too); `otool -Iv` for `__got` slots; disassembly scan for the rare anonymous slot |
 | **Struct field offset** | EocServer → EntityWorld is at `+0x288` | No (until a class is restructured) | One‑time Ghidra/runtime; carried forward |
 
 `tools/offset_manifest.json` lists every address in both categories with its
@@ -31,9 +31,10 @@ python3 tools/port_offsets.py resolve
 # 2. Print copy-pasteable C for src/core/offset_table.c:
 python3 tools/port_offsets.py resolve --emit
 
-# 3. Paste the generated struct entry into g_offset_table[] and the remap
-#    rows into g_fn_remap_<yourversion>[] (add that array + a branch in
-#    offset_table_remap_fn for the new version string), then:
+# 3. Paste the generated struct entry into g_offset_table[]. The remap
+#    table g_fn_remap is a fixed two-column {6995620, 7209685} table: a
+#    third version needs a new column (and a matching branch in
+#    offset_table_remap_fn), not new rows. Then:
 cd build && cmake --build .
 
 # 4. Launch, load a save, and run the regression suite:
@@ -59,9 +60,21 @@ reproduces hand-done work before you trust it on a new version.
 
 The resolver classifies every item:
 
-- `[INFO] __DATA shift derived ...` — the uniform shift for non-exported globals
-  (e.g. `RPGStats::m_ptr`), computed from the `data_shift_anchor`. Sanity-check it
+- `[INFO] component_data_shift ...` — the signed delta from the 7209685-vintage
+  compiled-in TypeId constants to your version, computed from the
+  `data_shift_anchor`. It is applied ONLY to the TypeId-global family (proven
+  uniform); every data singleton resolves by its own symbol. Sanity-check it
   looks like a small, plausible delta.
+- `[WARN] ... MANUAL — anonymous slot` — a global with no symbol at all (e.g.
+  `global_switches_ptr`, an anonymous `__common` slot). It does NOT follow the
+  uniform shift (it moved -0x24000 between 6995620 and 7209685 while its
+  neighbors moved +0x8000): re-derive it by disassembly (ADRP+LDR reference
+  scan; it is the hot slot written by `App::CreateGlobalSwitches`).
+- `[WARN] ... ABI CHANGED` — the symbol resolved, but its signature no longer
+  matches the C wrapper that calls it (e.g. the 7209685 Interrupt
+  `ExecuteStatsFunctors` gained a leading `ecs::EntityWorld&`). The tool emits
+  0 for it; write a new wrapper before enabling. **Address validity is not ABI
+  validity — always diff the demangled signature against the wrapper.**
 - `[WARN] ... AMBIGUOUS` — the symbol matched more than one address (e.g. const
   vs non-const overload). The tool takes the lowest; **make the manifest `symbol`
   more specific** (full signature) so it's unique, then re-run.
@@ -101,7 +114,10 @@ so future ports resolve it automatically:
 - A called game function → `remap_functions` (or `offset_table_functions` if it
   has a dedicated `VersionOffsets` field). Give the exact demangled `symbol` and
   its current-version `baseline` address.
-- A non-exported singleton pointer → `data_singletons` with its `baseline` offset.
+- A singleton pointer global → `data_singletons` with `method: "symbol"` and its
+  demangled `symbol` (plain `nm` resolves local symbols too). Use
+  `method: "got"` for `__DATA_CONST,__got` slots and `method: "disasm"` (with a
+  `note` describing the derivation) only when there is truly no symbol.
 - A field offset inside an object → `struct_offsets`.
 
 Find the exact symbol string with:
@@ -115,9 +131,12 @@ normalized during matching).
 
 ## How the remap table works (background)
 
-Many subsystems hold a hardcoded *baseline* (6995620) game-function address and
-call it as a function pointer. `offset_table_remap_fn(addr)` (in `offset_table.c`)
-returns the correct address for the running version, or **0 if it isn't in the
-remap table — in which case the caller skips that feature instead of jumping to a
+Several subsystems hold a hardcoded game-function address (mixed vintages:
+some 6995620, some 7209685) and call it as a function pointer.
+`offset_table_remap_fn(addr)` (in `offset_table.c`) matches the address against
+EITHER column of the two-column `g_fn_remap` table and returns the running
+version's column. It is fail-closed: an unknown version, or an address not in
+the table, returns **0 — the caller skips that feature instead of jumping to a
 stale address and crashing.** So even an un-ported function degrades gracefully.
-The tool generates the `g_fn_remap_<version>[]` rows for you.
+The tool generates the column values for you; entries flagged `abi_changed` in
+the manifest emit 0 until a matching wrapper exists.

--- a/ghidra/offsets/OSIRIS_DATABASES.md
+++ b/ghidra/offsets/OSIRIS_DATABASES.md
@@ -1,0 +1,128 @@
+# Osiris Database Access (macOS) — Osi.DB_* fix
+
+**Problem:** `Osi.DB_*:Get()` (DB_PartyMembers, DB_Players, DB_Avatars, DB_Is_InCombat…)
+always returns empty on macOS, breaking every mod that reads an Osiris database
+(e.g. **Sit This One Out** — its cantrip-grant loop iterates `DB_PartyMembers`).
+
+## Root cause (VERIFIED live 2026-07-12)
+
+Osiris keeps functions in **two** indexes inside `COsiFunctionMan`:
+1. A numeric **runtime id-index** (`pFunctionData(uint)`) — what the macOS port
+   brute-force probes in `osi_func_enumerate()`. **Databases are NOT in it.**
+2. A **name index** (`CSearchIndex<COsiFunctionData*, COsiString, 1023>`) — where
+   databases live. The port never walked this → DBs unresolvable.
+
+Confirmed: re-enumeration after story load still finds exactly 1303 functions,
+zero databases. Databases have **`OsiFunctionId == 0`** (no dispatch id), so
+`InternalQuery`-by-id cannot serve them. Windows reads their `Facts` list directly.
+
+## Name index layout — VERIFIED (libOsiris `COsiFunctionMan::pFunctionData(CKey)` @ 0x29b88; live-probed)
+
+- `_OsiFunctionMan` global = libOsiris base + **0x9f348**; deref → `manager`.
+- Name buckets at **manager + 0** (before the id runtime-index at manager+0x5ff0).
+- `bucket[i] = manager + i*0x18` (1023 buckets). Tree root = `*(bucket + 0x8)`.
+- Tree node: left = `*(node+0x00)`, right = `*(node+0x08)`,
+  key COsiString at `node+0x20`, **value `COsiFunctionData*` = `*(node+0x38)`**.
+- Walk is implemented in `osi_func_enumerate_by_name()` (osiris_functions.c) — a
+  read-only, bounded traversal. **Traversal VERIFIED correct** (live-probed:
+  reaches `DB_SHA_NightsongPrison_FadeEvents`, `DB_UND_ChestOfMundane`, … type=4).
+
+## COsiFunctionData (def) layout — VERIFIED offsets (live)
+
+| Offset | Field | Notes |
+|--------|-------|-------|
+| +0x18 | `FunctionSignature*` | → +0x08 `const char* Name` (extraction works) |
+| +0x20 | `NodeRef.Id` (u32) | node id → resolve Node → Database |
+| **+0x24** | `Type` (u32) | **=4 for Database** (NOTE: id-path wrongly reads type at +0x28=Key[0]) |
+| +0x28 | `Key[4]` (u32×4) | handle source for normal funcs |
+| +0x38 | `OsiFunctionId` (u32) | **=0 for databases** ← why the id-walk skipped them |
+
+## The fix (Windows-parity) — read Facts directly
+
+Windows (`Lua/Osiris/Function.inl` `LuaGet`):
+```cpp
+db = function_->Node.Get()->Database.Get();
+head = db->Facts.Head; current = head->Next;
+while (current != head) { /* current->Item = TupleVec row */ current = current->Next; }
+```
+Windows `Database` (`GameDefinitions/Osiris.h`):
+```cpp
+struct Database { uint32_t DatabaseId; void* FactsVMT; List<TupleVec> Facts; Vector<uint32_t> ParamTypes; uint8_t NumParams; };
+```
+`List` is circular: `Facts.Head` sentinel; nodes have `Next` + `Item` (TupleVec = vector of TypedValue).
+
+## FULL RESOLUTION CHAIN — VERIFIED via libOsiris arm64 disassembly (2026-07-12)
+
+macOS Osiris uses `CReteDBase` (the database, holds a `std::list<CTuple>`),
+`CTuple` = `COsiSOOList<COsiTypedValue,8>`, `COsiTypedValue` (16 bytes).
+All offsets below are from disassembly of the named functions.
+
+**Globals** (libOsiris file offsets; runtime = libOsirisBase + off;
+libOsirisBase = &`_OsiFunctionMan` − 0x9f348, or dlsym `_ReteNodeFactory`):
+- `_ReteNodeFactory` @ **0x9f338** — holds a **pointer** to the node factory.
+- Databases manager pointer @ **0x9f5b0** (alias also at 0x9a4d8).
+- Both factory & dbmgr: `+0x00` = id counter (u32), `+0x08`..`+0x10` = `std::vector<T*>`
+  (`__begin_`=+0x08, `__end_`=+0x10). **Element by id: `*( *(mgr+0x08) + (id-1)*8 )`.**
+  (VERIFIED: db serialize loop `sub w9,id,#1; ldr x0,[begin, w9, lsl#3]`.)
+
+**Chain** (`CreateReteFact` @ 0x6ba5c; `CReteDBase::Select` @ 0x5da40):
+1. Name-index walk → `def` (COsiFunctionData*) for the DB name (VERIFIED live).
+   `nodeId = u32 @ def+0x20`, `type(=4) @ def+0x24`.
+2. `factory = *(base+0x9f338)`; `node = *( *(factory+0x08) + (nodeId-1)*8 )`.
+   Validate `u32 @ node+0x08 == nodeId`. (fact node = `CReteNode`)
+3. `dbId = u32 @ node+0x18`.
+4. `dbmgr = *(base+0x9f5b0)`; `db = *( *(dbmgr+0x08) + (dbId-1)*8 )` = **CReteDBase**.
+   Validate `u32 @ db+0x00 == dbId`.
+5. **Facts** (std::list<CTuple> embedded at `db+0x10` sentinel):
+   - `count = u32 @ db+0x20`; `first = ptr @ db+0x18`; end sentinel = `db+0x10`.
+   - list node: `__next_ = ptr @ n+0x08`; **CTuple value @ n+0x10**.
+   - iterate: `n = first; while (n != db+0x10) { tuple = n+0x10; n = *(n+0x08); }`.
+6. **CTuple** = `COsiSOOList<COsiTypedValue,8>`:
+   - `size = u32 @ tuple+0x80`; `cap = u32 @ tuple+0x84`;
+   - `data = (cap < 9) ? (tuple+0x00) : *(tuple+0x00)`; column i at `data + i*0x10`.
+7. **COsiTypedValue** (16 bytes): `typeId = u16 @ tv+0x08`; `value = 8 bytes @ tv+0x00`
+   (char* for STRING/GUIDSTRING & custom GUID subtypes; int64 for INTEGER; float for REAL).
+   Read *(tv+0x00) as ptr → C string for string types; else numeric.
+
+**Note:** databases have `OsiFunctionId==0` (def+0x38) → do NOT dispatch via
+InternalQuery; read Facts as above (Windows parity).
+
+## Implementation plan
+
+1. In `osi_func_enumerate_by_name()`: for `Type==4` (Database) at def+0x24, store the
+   **def pointer** in a name→def registry (DBs have no id to cache under).
+2. New `osi_db_read_facts(def, L, filterArgs)` — resolve Node→Database→Facts, walk
+   the circular list, push each matching tuple as a Lua row (mirror Windows `LuaGet`).
+3. `lua_osi_db_get`: if the DB name is in the registry, call `osi_db_read_facts`
+   instead of the (unusable) InternalQuery-by-id path.
+
+## Code state (integrated from PR #93, 2026-07-29)
+
+- `osiris_functions.c`: `osi_func_enumerate_by_name()` (name-index walk) +
+  `osi_func_cache_def()` + the `osi_db_register`/`osi_db_lookup` registry
+  (databases have `OsiFunctionId==0`, so they are registered name→def, not
+  id-cached). Widened `osi_func_enumerate()` ranges/caps + idempotent.
+- `main.c`: `osi_db_read_facts()` implements the full resolution chain above;
+  `lua_osi_db_get` prefers it for any registered DB. fake_Event makes a
+  one-shot call to `osi_func_enumerate_by_name()` on
+  SavegameLoaded/LevelGameplayStarted (`g_dbNamesEnumerated`).
+- The game-image OsirisInterface instance slot (`0x8a86128` on 7209685, used by
+  `osi_read_param_defs`) lives in the offset table (`osiris_interface_ptr`,
+  fail-closed for unknown versions) and is audited by
+  `tests/harness/test_offset_audit.py::test_osiris_interface_slot_matches_disasm`,
+  which re-derives it from OsirisQuery's `adrp`+`ldr` pair on every run.
+- All libOsiris globals used here (`_OsiFunctionMan` 0x9f348, `_ReteNodeFactory`
+  0x9f338, `_OsiStringTable` 0x96cb8, db manager 0x9f5b0 alias
+  `_ReteDBaseFactory` 0x9a4d8) are exported symbols — re-derive via `nm -gU`
+  if libOsiris ever changes.
+
+## Live probe cheat-sheet (Ext.Debug over /tmp/bg3se.sock)
+```
+base = Ext.Memory.GetModuleBase("Osiris")           -- e.g. 0x10f6a4000
+man  = Ext.Debug.ReadPtr(base + 0x9f348)             -- COsiFunctionMan
+root = Ext.Debug.ReadPtr(man + b*0x18 + 0x8)         -- bucket b tree root
+val  = Ext.Debug.ReadPtr(node + 0x38)                -- COsiFunctionData*
+name = Ext.Debug.ReadString(Ext.Debug.ReadPtr(val+0x18) + 0x08, 64)
+```
+⚠️ Keep probes BOUNDED (≤~50 buckets/call). A full recursive 1023-bucket walk from
+Lua crashed the game.

--- a/src/audio/audio_manager.c
+++ b/src/audio/audio_manager.c
@@ -15,6 +15,7 @@
 #include "audio_manager.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/offset_table.h"
 #include "../strings/fixed_string.h"
 #include <stdlib.h>
 #include <string.h>
@@ -24,8 +25,9 @@
 // Constants and Offsets
 // ============================================================================
 
-// ResourceManager::m_ptr (shared with resource_manager.c)
-#define OFFSET_RESOURCEMANAGER_PTR   0x08a8f070
+// ResourceManager::m_ptr — sourced from offset_table at runtime
+// Fallback value kept for reference: 0x08a8f070 (4.1.1.6995620)
+#define OFFSET_RESOURCEMANAGER_PTR_FALLBACK  0x08a8f070
 
 // SoundManager offset within ResourceManager (needs runtime discovery)
 // Placeholder - probe ResourceManager struct to find actual offset
@@ -116,15 +118,24 @@ bool audio_manager_init(void *main_binary_base) {
     }
 
     g_audio.main_binary_base = main_binary_base;
-    g_audio.resource_manager_ptr = (void **)((uintptr_t)main_binary_base + OFFSET_RESOURCEMANAGER_PTR);
 
-    // Resolve ls::STDString constructor for PlayExternalSound path parameter
-    g_audio.stdstring_ctor = (STDStringCtorFn)((uintptr_t)main_binary_base + OFFSET_STDSTRING_CTOR);
+    const VersionOffsets *off = offset_table_get();
+    if (off && off->resource_mgr_ptr) {
+        g_audio.resource_manager_ptr = (void **)offset_table_resolve(off->resource_mgr_ptr);
+    } else {
+        g_audio.resource_manager_ptr = (void **)((uintptr_t)main_binary_base + OFFSET_RESOURCEMANAGER_PTR_FALLBACK);
+    }
+
+    // Resolve ls::STDString constructor (remap the hardcoded 6995620 address).
+    // NULL if no verified address -> PlayExternalSound's string path is skipped.
+    uint64_t stdstr_ghidra = offset_table_remap_fn(0x100000000ULL + OFFSET_STDSTRING_CTOR);
+    g_audio.stdstring_ctor = stdstr_ghidra
+        ? (STDStringCtorFn)((uintptr_t)main_binary_base + (stdstr_ghidra - 0x100000000ULL))
+        : NULL;
 
     log_message("[Audio] Audio manager initialized");
     log_message("[Audio]   Base: %p", main_binary_base);
-    log_message("[Audio]   ResourceManager::m_ptr at offset 0x%x -> %p",
-                OFFSET_RESOURCEMANAGER_PTR, (void *)g_audio.resource_manager_ptr);
+    log_message("[Audio]   ResourceManager::m_ptr -> %p", (void *)g_audio.resource_manager_ptr);
     log_message("[Audio]   STDString ctor: %p", (void *)g_audio.stdstring_ctor);
 
     g_audio.initialized = true;

--- a/src/audio/audio_manager.c
+++ b/src/audio/audio_manager.c
@@ -68,8 +68,10 @@ typedef struct {
     };
 } LSSTDString;
 
-// Game's ls::STDString(const char*) constructor (Ghidra: 0x10651fb60)
-#define OFFSET_STDSTRING_CTOR  0x0651fb60ULL
+// Game's ls::STDString(const char*) constructor.
+// 4.1.1.7209685 vintage, nm-verified (0x10650e718 t ls::STDString::STDString(char const*)).
+// Passed through offset_table_remap_fn() (either-vintage match, fail-closed).
+#define OFFSET_STDSTRING_CTOR  0x0650e718ULL
 typedef void (*STDStringCtorFn)(LSSTDString *this_, const char *str);
 
 static void ls_stdstring_init(LSSTDString *out, const char *str, STDStringCtorFn ctor) {

--- a/src/console/console.c
+++ b/src/console/console.c
@@ -16,7 +16,6 @@
 #include "../lifetime/lifetime.h"
 #include "../entity/component_typeid.h"
 #include "../osiris/osiris_functions.h"
-#include "../input/focusless_input.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -665,7 +664,11 @@ static void socket_process_client(lua_State *L, int slot) {
             if (*client_len > 0) {
                 client_buf[*client_len] = '\0';
                 process_line(L, client_buf, slot);
-                focusless_input_mark_socket_ready();
+                // NOTE: do NOT mark the splash auto-dismisser done here — the
+                // harness polls !identity over this socket DURING boot, which
+                // used to cancel the dismisser after 0 attempts and strand the
+                // game on "Press any key". The dismisser now stops itself on
+                // game-state advance (focusless_input.m).
                 socket_send_prompt(slot);
                 *client_len = 0;
             }

--- a/src/console/console.c
+++ b/src/console/console.c
@@ -16,6 +16,7 @@
 #include "../lifetime/lifetime.h"
 #include "../entity/component_typeid.h"
 #include "../osiris/osiris_functions.h"
+#include "../input/focusless_input.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -414,6 +415,9 @@ static int dispatch_console_command(lua_State *L, const char *line, int client_s
         console_printf("  !identity - JSON identity/readiness (pid, session_init, stats_ready)");
         console_printf("  !typeids - Show TypeId resolution status");
         console_printf("  !probe_osidef [N] - Dump OsiFunctionDef layout for N functions (default 5)");
+        console_printf("  !splash_done - Stop the focusless splash auto-dismisser");
+        console_printf("  !click <xf> <yf> - In-process click at view fraction (no cursor move)");
+        console_printf("  !key <code> - In-process key press (mac virtual keycode)");
         console_printf("  !osi_info <name> - Probe Osiris function cache + pointer chain for <name>");
         for (int i = 0; i < s_command_count; i++) {
             console_printf("  !%s", s_commands[i].name);
@@ -459,6 +463,53 @@ static int dispatch_console_command(lua_State *L, const char *line, int client_s
     // Built-in !typeids command
     if (strcmp(cmd_name, "typeids") == 0) {
         component_typeid_dump_to_console();
+        return 1;
+    }
+
+    // Built-in !splash_done — stop the focusless splash auto-dismisser.
+    // Sent by the harness watchdog the moment OCR sees the main menu, so the
+    // repeating Escape/Space/click loop cannot fight menu/modal interaction.
+    if (strcmp(cmd_name, "splash_done") == 0) {
+        focusless_input_mark_socket_ready();
+        console_printf("splash auto-dismiss stopped");
+        return 1;
+    }
+
+    // Built-in !click <xf> <yf> — in-process synthetic click at a fraction of
+    // the LSMTLView bounds (top-left origin). No physical cursor movement and
+    // no focus required; works while the window is hidden or off-screen.
+    if (strcmp(cmd_name, "click") == 0) {
+        char *xs = strtok(NULL, " \t");
+        char *ys = strtok(NULL, " \t");
+        if (!xs || !ys) {
+            console_printf("Usage: !click <x_fraction> <y_fraction>  (0.0-1.0, top-left origin)");
+            return 1;
+        }
+        double xf = atof(xs);
+        double yf = atof(ys);
+        if (xf < 0.0 || xf > 1.0 || yf < 0.0 || yf > 1.0) {
+            console_printf("!click: fractions must be within 0.0-1.0");
+            return 1;
+        }
+        bool ok = focusless_input_post_mouse_click(xf, yf);
+        console_printf("click %s at (%.3f, %.3f)", ok ? "posted" : "failed", xf, yf);
+        return 1;
+    }
+
+    // Built-in !key <keycode> — in-process key press (macOS virtual keycode).
+    if (strcmp(cmd_name, "key") == 0) {
+        char *ks = strtok(NULL, " \t");
+        if (!ks || !ks[0]) {
+            console_printf("Usage: !key <mac_virtual_keycode>  (e.g. 36=Return, 49=Space, 53=Escape)");
+            return 1;
+        }
+        int code = atoi(ks);
+        if (code < 0 || code > 0xFF) {
+            console_printf("!key: keycode must be 0-255");
+            return 1;
+        }
+        bool ok = focusless_input_post_key_press((uint16_t)code, 0);
+        console_printf("key %d %s", code, ok ? "posted" : "failed");
         return 1;
     }
 

--- a/src/core/offset_table.c
+++ b/src/core/offset_table.c
@@ -1,0 +1,237 @@
+/**
+ * offset_table.c - Per-version memory offset table for BG3SE-macOS
+ *
+ * To add support for a new BG3 version, DON'T do it by hand — run the resolver:
+ *     python3 tools/port_offsets.py resolve --emit
+ * and paste its output (the struct entry + the g_fn_remap_<ver>[] rows) here.
+ * The recipe of every address is tools/offset_manifest.json; see docs/PORTING.md.
+ * Validate any change with:  python3 tools/port_offsets.py verify
+ *
+ * Manual fallback (if a symbol can't be resolved):
+ *   - Singleton offsets: `nm` the binary, or runtime probe (Ext.Debug.ReadPtr).
+ *   - Function offsets: `nm`/Ghidra. Fields left 0 = "unknown" -> callers skip
+ *     that feature gracefully rather than crash.
+ *
+ * All offsets are (Ghidra address - 0x100000000), i.e. offset from binary load base.
+ */
+
+#include "offset_table.h"
+#include "version_detect.h"
+#include "logging.h"
+
+#include <string.h>
+
+// ============================================================================
+// Version Table
+// ============================================================================
+
+static const VersionOffsets g_offset_table[] = {
+
+    /* ------------------------------------------------------------------
+     * 4.1.1.6995620 — original verified version
+     * All offsets discovered via Ghidra analysis (Dec 2025).
+     * ------------------------------------------------------------------ */
+    {
+        .version                 = "4.1.1.6995620",
+
+        /* Singleton pointer globals */
+        .eocserver_ptr           = 0x0898e8b8,  // esv::EocServer::m_ptr
+        .eocclient_ptr           = 0x0898c968,  // ecl::EocClient::m_ptr
+        .spell_proto_mgr_ptr     = 0x089bac80,  // SpellPrototypeManager::m_ptr
+        .rpgstats_ptr            = 0x089c5730,  // RPGStats::m_ptr
+        .resource_mgr_ptr        = 0x08a8f070,  // ResourceManager::m_ptr
+        .level_mgr_ptr           = 0x08a3be40,  // LevelManager::m_ptr
+        .global_template_mgr_ptr = 0x08a88508,  // ls::GlobalTemplateManager::m_ptr
+        .cache_template_mgr_ptr  = 0x08a309a8,  // CacheTemplateManager::m_ptr
+        .level_cache_mgr_ptr     = 0x08a735d8,  // Level::s_CacheTemplateManager
+        .staticdata_mstate_ptr   = 0x083c4a68,  // ImmutableDataHeadmaster::m_State
+        .gst_ptr                 = 0x08aeccd8,  // ls::gGlobalStringTable
+
+        /* Function offsets */
+        .fn_feat_getfeats        = 0x01b752b4,  // FeatManager::GetFeats
+        .fn_getallfeats          = 0x0120b3e8,  // GetAllFeats
+        .fn_get_background       = 0x02994834,  // Get<eoc::BackgroundManager>
+        .fn_get_origin           = 0x0341c42c,  // Get<eoc::OriginManager>
+        .fn_get_class            = 0x0262f184,  // Get<eoc::ClassDescriptions>
+        .fn_get_progression      = 0x03697f0c,  // Get<eoc::ProgressionManager>
+        .fn_get_actionresource   = 0x011a4494,  // Get<eoc::ActionResourceTypes>
+        .fn_get_template_raw     = 0x05f96304,  // GlobalTemplateManager::GetTemplateRaw
+        .fn_cache_template       = 0x05d31ce4,  // CacheTemplateManagerBase::CacheTemplate
+
+        /* Entity system */
+        .fn_try_get_uuid_mapping = 0x010dc924,  // TryGetSingleton<uuid::ToHandleMappingComponent>
+        .fn_storage_tryget       = 0x0636b27c,  // ecs::EntityStorageContainer::TryGet
+        .fn_spell_proto_init     = 0x01f72754,  // eoc::SpellPrototype::Init
+        .component_data_shift    = 0,           // baseline: TypeId addresses unshifted
+    },
+
+    /* ------------------------------------------------------------------
+     * 4.1.1.7209685 — in use as of June 2026
+     *
+     * The entire __DATA segment shifted by a uniform +0x8000 relative to
+     * 6995620. This was established by:
+     *   - Export-trie diff: ls::TypeId<eoc::FeatManager,...>::m_TypeIndex
+     *     moved 0x1088efd00 -> 0x1088f7d00 (exactly +0x8000).
+     *   - otool ADRP/LDR reference-frequency scan: every old singleton
+     *     offset + 0x8000 lands on a hot (heavily-referenced) __DATA slot.
+     *   - Runtime structural validation against a loaded session:
+     *       rpgstats(+0xd4)=16994 objects, fixedstrings pool at +0x348;
+     *       ResourceManager banks valid at +0x28/+0x30;
+     *       StaticData TypeContext traversal yields 121 named managers
+     *       (FeatManager, RaceManager, BackgroundManager, ... ClassDescriptions).
+     * So every singleton below is simply (6995620 value + 0x8000).
+     *
+     * Function offsets live in __TEXT, which did NOT shift uniformly (the
+     * three template accessors moved -0x105E8, the feat funcs -0x1BAA0, the
+     * Get<T> accessors ~-0x1A7A8), so they were resolved individually by
+     * symbol-table lookup (nm) rather than a constant shift. The macOS
+     * binary is essentially fully symbolized (765k local+global symbols),
+     * so each function below is the address of its named symbol.
+     * ------------------------------------------------------------------ */
+    {
+        .version                 = "4.1.1.7209685",
+
+        /* Singleton pointer globals — uniform +0x8000 vs 6995620 (validated) */
+        .eocserver_ptr           = 0x089968b8,  // 0x0898e8b8 + 0x8000
+        .eocclient_ptr           = 0x08994968,  // 0x0898c968 + 0x8000
+        .spell_proto_mgr_ptr     = 0x089c2c80,  // 0x089bac80 + 0x8000
+        .rpgstats_ptr            = 0x089cd730,  // 0x089c5730 + 0x8000 (count=16994)
+        .resource_mgr_ptr        = 0x08a97070,  // 0x08a8f070 + 0x8000 (banks valid)
+        .level_mgr_ptr           = 0x08a43e40,  // 0x08a3be40 + 0x8000
+        .global_template_mgr_ptr = 0x08a90508,  // 0x08a88508 + 0x8000
+        .cache_template_mgr_ptr  = 0x08a389a8,  // 0x08a309a8 + 0x8000
+        .level_cache_mgr_ptr     = 0x08a7b5d8,  // 0x08a735d8 + 0x8000
+        .staticdata_mstate_ptr   = 0x083cca68,  // 0x083c4a68 + 0x8000 (121 managers)
+        .gst_ptr                 = 0x08af4cd8,  // 0x08aeccd8 + 0x8000 (val=GST ptr, validated)
+
+        /* Function offsets (__TEXT) — resolved by nm symbol lookup on the
+         * 7209685 binary; non-uniform shift, see note above. */
+        .fn_feat_getfeats        = 0x01b59814,  // eoc::FeatManager::GetFeats() const
+        .fn_getallfeats          = 0x011ef948,  // eoc::character_creation::GetAllFeats(Environment const&)
+        .fn_get_background       = 0x0297a068,  // ImmutableDataHeadmaster::Get<eoc::BackgroundManager>() const
+        .fn_get_origin           = 0x03401c84,  // ImmutableDataHeadmaster::Get<eoc::OriginManager>() const
+        .fn_get_class            = 0x02614874,  // ImmutableDataHeadmaster::Get<eoc::ClassDescriptions>() const
+        .fn_get_progression      = 0x0367d764,  // ImmutableDataHeadmaster::Get<eoc::ProgressionManager>() const
+        .fn_get_actionresource   = 0x011889f4,  // ImmutableDataHeadmaster::Get<eoc::ActionResourceTypes>() const
+        .fn_get_template_raw     = 0x05f85d1c,  // ls::GlobalTemplateManager::GetTemplateRaw(FixedString const&) const
+        .fn_cache_template       = 0x05d216fc,  // ls::CacheTemplateManagerBase::CacheTemplate(...)
+
+        /* Entity system (verified end-to-end).
+         * fn_try_get_uuid_mapping: ecs::legacy::Helper::TryGetSingleton<
+         *   uuid::ToHandleMappingComponent const> (symbol-verified, old-0x1baa0).
+         * The earlier crash was NOT this offset — it was read_eocserver_from_global
+         * reading a stale EocServer address, yielding a garbage EntityWorld.
+         * With the EocServer source fixed (offset table eocserver_ptr) the
+         * EntityWorld at EocServer+0x288 is valid (probe-confirmed: 0xc8bb74000
+         * with sane sub-structure), and EocServer::StartUp's `ldr x20,[x19,#0x288]`
+         * confirms +0x288 is unchanged for this version.
+         * component_data_shift: uniform +0x8000 __DATA shift. */
+        .fn_try_get_uuid_mapping = 0x010c0e84,
+        .fn_storage_tryget       = 0x0635ac94,  // ecs::EntityStorageContainer::TryGet (old 0x0636b27c - 0x105E8)
+        .fn_spell_proto_init     = 0x01f56cb4,  // eoc::SpellPrototype::Init (old 0x01f72754 - 0x1baa0)
+        .component_data_shift    = 0x8000,
+    },
+
+};
+
+#define NUM_VERSIONS (sizeof(g_offset_table) / sizeof(g_offset_table[0]))
+
+// ============================================================================
+// Per-version function-address remap
+// ============================================================================
+//
+// Many subsystems still hold hardcoded 6995620 game-function addresses (called
+// as function pointers). On a shifted version these point at the wrong function
+// and SIGBUS when invoked. Rather than thread ~20 fields through VersionOffsets,
+// callers wrap their hardcoded 6995620 Ghidra address with offset_table_remap_fn()
+// which returns the correct address for the active version. All values are full
+// Ghidra addresses (>= 0x100000000); all new values are symbol-verified.
+
+typedef struct { uint64_t from6995620; uint64_t to; } FnRemap;
+
+static const FnRemap g_fn_remap_7209685[] = {
+    { 0x1064b9ebc, 0x1064a8a74 },  // ls::FixedString::Create(char const*, int)   (ABI verified)
+    { 0x1060cc608, 0x1060bc020 },  // ls::ResourceContainer::GetResource
+    { 0x105783a38, 0x10577399c },  // ExecuteStatsFunctor (main dispatcher)
+    { 0x105787918, 0x10577787c },  // esv::functor::ExecuteStatsFunctors<AttackTarget>
+    { 0x105787c6c, 0x105777bd0 },  //   <AttackPosition>
+    { 0x10578975c, 0x1057796c0 },  //   <Move>
+    { 0x10578a918, 0x10577a87c },  //   <Target>
+    { 0x10578e4d8, 0x10577e43c },  //   <NearbyAttacked>
+    { 0x10578fba8, 0x10577fb0c },  //   <NearbyAttacking>
+    { 0x105790a28, 0x10578098c },  //   <Equip>
+    { 0x105792a90, 0x1057829f4 },  //   <Source>
+    { 0x1057965e4, 0x105786548 },  //   <Interrupt>
+    { 0x106534d54, 0x10652390c },  // ls::TranslatedStringRepository::TryGet
+    { 0x106535148, 0x106523d00 },  // ls::TranslatedStringRepository::Get
+    { 0x106532590, 0x106521148 },  // ls::TranslatedStringRepository::AddTranslatedString
+    { 0x1063d5998, 0x1063c4550 },  // net::MessageFactory::GetFreeMessage
+    { 0x10651fb60, 0x10650e718 },  // ls::STDString::STDString(char const*)  (audio PlayExternalSound)
+    // Note: bik::BinkManager::LoadVideo (0x10390b6cc) is unchanged across versions.
+    // GetComponent<T> template addresses are intentionally NOT remapped: that path
+    // is dead on macOS (templates inlined), so it returns 0 here and is skipped.
+};
+
+// ============================================================================
+// State
+// ============================================================================
+
+static const VersionOffsets *g_active = NULL;
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+void offset_table_init(void) {
+    const char *version = version_detect_get_version();
+    if (!version) {
+        log_message("[OffsetTable] Version not detected — all address-dependent features disabled");
+        return;
+    }
+
+    for (int i = 0; i < (int)NUM_VERSIONS; i++) {
+        if (strcmp(g_offset_table[i].version, version) == 0) {
+            g_active = &g_offset_table[i];
+            log_message("[OffsetTable] Loaded offsets for %s", version);
+            return;
+        }
+    }
+
+    log_message("[OffsetTable] Version %s not in table — running in degraded mode. "
+                "Add a new entry to src/core/offset_table.c to enable full features.",
+                version);
+}
+
+const VersionOffsets *offset_table_get(void) {
+    return g_active;
+}
+
+void *offset_table_resolve(uintptr_t offset) {
+    if (!offset) return NULL;
+    void *base = version_detect_get_binary_base();
+    if (!base) return NULL;
+    return (void *)((uintptr_t)base + offset);
+}
+
+void *offset_table_fn(uintptr_t offset) {
+    return offset_table_resolve(offset);
+}
+
+uint64_t offset_table_remap_fn(uint64_t ghidra_addr_6995620) {
+    // Baseline / unknown version: use the caller's address unchanged.
+    if (!g_active || g_active == &g_offset_table[0]) {
+        return ghidra_addr_6995620;
+    }
+    // 7209685 (and any future shifted version with a remap table): look up the
+    // verified equivalent. Anything NOT in the table is returned as 0 so the
+    // caller disables that feature instead of jumping to a stale address.
+    if (strcmp(g_active->version, "4.1.1.7209685") == 0) {
+        for (size_t i = 0; i < sizeof(g_fn_remap_7209685) / sizeof(g_fn_remap_7209685[0]); i++) {
+            if (g_fn_remap_7209685[i].from6995620 == ghidra_addr_6995620) {
+                return g_fn_remap_7209685[i].to;
+            }
+        }
+        return 0;  // unmapped on a shifted version -> disabled (graceful)
+    }
+    return ghidra_addr_6995620;
+}

--- a/src/core/offset_table.c
+++ b/src/core/offset_table.c
@@ -46,6 +46,7 @@ static const VersionOffsets g_offset_table[] = {
         .level_cache_mgr_ptr     = 0x08a735d8,  // Level::s_CacheTemplateManager
         .staticdata_mstate_ptr   = 0x083c4a68,  // ImmutableDataHeadmaster::m_State
         .gst_ptr                 = 0x08aeccd8,  // ls::gGlobalStringTable
+        .global_switches_ptr     = 0x08b18f30,  // EoCGlobalSwitches* (May 2026 RE: VMGameData init)
 
         /* Function offsets */
         .fn_feat_getfeats        = 0x01b752b4,  // FeatManager::GetFeats
@@ -62,7 +63,8 @@ static const VersionOffsets g_offset_table[] = {
         .fn_try_get_uuid_mapping = 0x010dc924,  // TryGetSingleton<uuid::ToHandleMappingComponent>
         .fn_storage_tryget       = 0x0636b27c,  // ecs::EntityStorageContainer::TryGet
         .fn_spell_proto_init     = 0x01f72754,  // eoc::SpellPrototype::Init
-        .component_data_shift    = 0,           // baseline: TypeId addresses unshifted
+        .component_data_shift    = -0x8000,     // compiled-in __DATA constants are 7209685;
+                                                // this version's __DATA sits 0x8000 lower
     },
 
     /* ------------------------------------------------------------------
@@ -102,7 +104,16 @@ static const VersionOffsets g_offset_table[] = {
         .cache_template_mgr_ptr  = 0x08a389a8,  // 0x08a309a8 + 0x8000
         .level_cache_mgr_ptr     = 0x08a7b5d8,  // 0x08a735d8 + 0x8000
         .staticdata_mstate_ptr   = 0x083cca68,  // 0x083c4a68 + 0x8000 (121 managers)
+                                                // NOTE: this is the __DATA_CONST,__got SLOT whose
+                                                // contents = 0x108947ba0 (TypeContext<ImmutableData-
+                                                // Headmaster>::m_State object) — correct for the
+                                                // one-dereference traversal in staticdata_manager.c.
+                                                // nm cannot see it; audit via otool -Iv / __got.
         .gst_ptr                 = 0x08af4cd8,  // 0x08aeccd8 + 0x8000 (val=GST ptr, validated)
+        .global_switches_ptr     = 0x08af4f30,  // EoCGlobalSwitches* — NOT old+0x8000 (slot moved
+                                                // -0x24000). Verified 2026-07-29: 916 disasm refs
+                                                // across 593 fns incl. App::CreateGlobalSwitches()
+                                                // and BaseApp::CreateGlobalSwitches().
 
         /* Function offsets (__TEXT) — resolved by nm symbol lookup on the
          * 7209685 binary; non-uniform shift, see note above. */
@@ -129,7 +140,8 @@ static const VersionOffsets g_offset_table[] = {
         .fn_try_get_uuid_mapping = 0x010c0e84,
         .fn_storage_tryget       = 0x0635ac94,  // ecs::EntityStorageContainer::TryGet (old 0x0636b27c - 0x105E8)
         .fn_spell_proto_init     = 0x01f56cb4,  // eoc::SpellPrototype::Init (old 0x01f72754 - 0x1baa0)
-        .component_data_shift    = 0x8000,
+        .component_data_shift    = 0,           // compiled-in __DATA constants ARE this
+                                                // vintage (nm-audited 7209685) — no shift
     },
 
 };
@@ -140,16 +152,18 @@ static const VersionOffsets g_offset_table[] = {
 // Per-version function-address remap
 // ============================================================================
 //
-// Many subsystems still hold hardcoded 6995620 game-function addresses (called
-// as function pointers). On a shifted version these point at the wrong function
-// and SIGBUS when invoked. Rather than thread ~20 fields through VersionOffsets,
-// callers wrap their hardcoded 6995620 Ghidra address with offset_table_remap_fn()
-// which returns the correct address for the active version. All values are full
-// Ghidra addresses (>= 0x100000000); all new values are symbol-verified.
+// Several subsystems hold hardcoded game-function Ghidra addresses (called as
+// function pointers). Rather than thread ~20 fields through VersionOffsets,
+// callers wrap their hardcoded address with offset_table_remap_fn(), which
+// matches EITHER column (the codebase carries mixed vintages) and returns the
+// active version's column. Fail-closed: unknown version, or an address absent
+// from the table, returns 0 — the caller disables that feature instead of
+// jumping to a stale address. All values are full Ghidra addresses
+// (>= 0x100000000); every 7209685 value is symbol-verified via nm.
 
-typedef struct { uint64_t from6995620; uint64_t to; } FnRemap;
+typedef struct { uint64_t addr_6995620; uint64_t addr_7209685; } FnRemap;
 
-static const FnRemap g_fn_remap_7209685[] = {
+static const FnRemap g_fn_remap[] = {
     { 0x1064b9ebc, 0x1064a8a74 },  // ls::FixedString::Create(char const*, int)   (ABI verified)
     { 0x1060cc608, 0x1060bc020 },  // ls::ResourceContainer::GetResource
     { 0x105783a38, 0x10577399c },  // ExecuteStatsFunctor (main dispatcher)
@@ -161,15 +175,21 @@ static const FnRemap g_fn_remap_7209685[] = {
     { 0x10578fba8, 0x10577fb0c },  //   <NearbyAttacking>
     { 0x105790a28, 0x10578098c },  //   <Equip>
     { 0x105792a90, 0x1057829f4 },  //   <Source>
-    { 0x1057965e4, 0x105786548 },  //   <Interrupt>
+    { 0x1057965e4, 0 },            //   <Interrupt> — 7209685 variant (0x105786548) gained a
+                                   //   leading ecs::EntityWorld& param (nm-verified); the old
+                                   //   wrapper ABI does not fit. 0 until a new wrapper exists.
     { 0x106534d54, 0x10652390c },  // ls::TranslatedStringRepository::TryGet
     { 0x106535148, 0x106523d00 },  // ls::TranslatedStringRepository::Get
     { 0x106532590, 0x106521148 },  // ls::TranslatedStringRepository::AddTranslatedString
     { 0x1063d5998, 0x1063c4550 },  // net::MessageFactory::GetFreeMessage
     { 0x10651fb60, 0x10650e718 },  // ls::STDString::STDString(char const*)  (audio PlayExternalSound)
-    // Note: bik::BinkManager::LoadVideo (0x10390b6cc) is unchanged across versions.
-    // GetComponent<T> template addresses are intentionally NOT remapped: that path
-    // is dead on macOS (templates inlined), so it returns 0 here and is skipped.
+    // NOTE: the functor rows above are additionally gated by
+    // FUNCTOR_ADDRS_VERIFIED_BUILD in functor_types.h — hooks stay off on
+    // 7209685 until each signature is ABI-verified (see functor_hooks.c).
+    // bik::BinkManager::LoadVideo (0x10390b6cc) is unchanged across versions.
+    // GetComponent<T> template addresses are intentionally NOT in this table:
+    // that path is dead on macOS (templates inlined) — remap returns 0 on
+    // every version and the path is skipped.
 };
 
 // ============================================================================
@@ -217,21 +237,20 @@ void *offset_table_fn(uintptr_t offset) {
     return offset_table_resolve(offset);
 }
 
-uint64_t offset_table_remap_fn(uint64_t ghidra_addr_6995620) {
-    // Baseline / unknown version: use the caller's address unchanged.
-    if (!g_active || g_active == &g_offset_table[0]) {
-        return ghidra_addr_6995620;
-    }
-    // 7209685 (and any future shifted version with a remap table): look up the
-    // verified equivalent. Anything NOT in the table is returned as 0 so the
-    // caller disables that feature instead of jumping to a stale address.
-    if (strcmp(g_active->version, "4.1.1.7209685") == 0) {
-        for (size_t i = 0; i < sizeof(g_fn_remap_7209685) / sizeof(g_fn_remap_7209685[0]); i++) {
-            if (g_fn_remap_7209685[i].from6995620 == ghidra_addr_6995620) {
-                return g_fn_remap_7209685[i].to;
-            }
+uint64_t offset_table_remap_fn(uint64_t ghidra_addr) {
+    // Fail closed: no active version row -> every remapped feature disabled.
+    if (!g_active) return 0;
+
+    int col;
+    if (strcmp(g_active->version, "4.1.1.6995620") == 0)      col = 0;
+    else if (strcmp(g_active->version, "4.1.1.7209685") == 0) col = 1;
+    else return 0;  // version in table but no remap column -> disabled
+
+    for (size_t i = 0; i < sizeof(g_fn_remap) / sizeof(g_fn_remap[0]); i++) {
+        if (g_fn_remap[i].addr_6995620 == ghidra_addr ||
+            g_fn_remap[i].addr_7209685 == ghidra_addr) {
+            return col ? g_fn_remap[i].addr_7209685 : g_fn_remap[i].addr_6995620;
         }
-        return 0;  // unmapped on a shifted version -> disabled (graceful)
     }
-    return ghidra_addr_6995620;
+    return 0;  // unmapped -> disabled (graceful)
 }

--- a/src/core/offset_table.c
+++ b/src/core/offset_table.c
@@ -47,6 +47,9 @@ static const VersionOffsets g_offset_table[] = {
         .staticdata_mstate_ptr   = 0x083c4a68,  // ImmutableDataHeadmaster::m_State
         .gst_ptr                 = 0x08aeccd8,  // ls::gGlobalStringTable
         .global_switches_ptr     = 0x08b18f30,  // EoCGlobalSwitches* (May 2026 RE: VMGameData init)
+        .osiris_interface_ptr    = 0,           // osi::OsirisInterface instance — never verified
+                                                // on this vintage (0 = param-defs reader disabled;
+                                                // osi_dynamic_call falls back to legacy guessing)
 
         /* Function offsets */
         .fn_feat_getfeats        = 0x01b752b4,  // FeatManager::GetFeats
@@ -114,6 +117,12 @@ static const VersionOffsets g_offset_table[] = {
                                                 // -0x24000). Verified 2026-07-29: 916 disasm refs
                                                 // across 593 fns incl. App::CreateGlobalSwitches()
                                                 // and BaseApp::CreateGlobalSwitches().
+        .osiris_interface_ptr    = 0x08a86128,  // osi::OsirisInterface instance slot. No nm symbol;
+                                                // verified 2026-07-29 by otool disasm of
+                                                // osi::OsirisInterface::OsirisQuery @ 0x105c093b0:
+                                                //   adrp x8, 0x108a86000 ; ldr x25, [x8, #0x128]
+                                                // (matches PR #93's live-verified chain; see
+                                                // ghidra/offsets/OSIRIS_DATABASES.md)
 
         /* Function offsets (__TEXT) — resolved by nm symbol lookup on the
          * 7209685 binary; non-uniform shift, see note above. */

--- a/src/core/offset_table.h
+++ b/src/core/offset_table.h
@@ -1,0 +1,119 @@
+/**
+ * offset_table.h - Per-version memory offset table for BG3SE-macOS
+ *
+ * All address-dependent features (stats, entity, staticdata, templates, audio,
+ * level) derive their runtime pointers from this table. Adding a new BG3 version
+ * means adding one row here; no other files need editing for the address changes.
+ *
+ * Addressing convention:
+ *   All fields are stored as offsets from the binary load base (i.e. the Ghidra
+ *   address minus 0x100000000). Runtime address = binary_base + field_value.
+ *   A field value of 0 means "unknown for this version — skip gracefully".
+ */
+
+#ifndef OFFSET_TABLE_H
+#define OFFSET_TABLE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    const char *version;                 // e.g. "4.1.1.6995620"
+
+    /* ------------------------------------------------------------------ */
+    /* Data-segment singleton pointer globals                              */
+    /* Offset from binary base; dereference once to get the object ptr.   */
+    /* ------------------------------------------------------------------ */
+
+    uintptr_t eocserver_ptr;            // esv::EocServer::m_ptr
+    uintptr_t eocclient_ptr;            // ecl::EocClient::m_ptr
+    uintptr_t spell_proto_mgr_ptr;      // SpellPrototypeManager::m_ptr
+    uintptr_t rpgstats_ptr;             // RPGStats::m_ptr
+    uintptr_t resource_mgr_ptr;         // ResourceManager::m_ptr
+    uintptr_t level_mgr_ptr;            // LevelManager::m_ptr
+    uintptr_t global_template_mgr_ptr;  // ls::GlobalTemplateManager::m_ptr
+    uintptr_t cache_template_mgr_ptr;   // CacheTemplateManager::m_ptr
+    uintptr_t level_cache_mgr_ptr;      // Level::s_CacheTemplateManager
+    uintptr_t staticdata_mstate_ptr;    // ImmutableDataHeadmaster::m_State
+    uintptr_t gst_ptr;                  // ls::gGlobalStringTable (FixedString pool)
+
+    /* ------------------------------------------------------------------ */
+    /* Function offsets                                                    */
+    /* Offset from binary base; cast directly to function pointer type.   */
+    /* ------------------------------------------------------------------ */
+
+    uintptr_t fn_feat_getfeats;         // FeatManager::GetFeats
+    uintptr_t fn_getallfeats;           // GetAllFeats (context capture)
+    uintptr_t fn_get_background;        // Get<eoc::BackgroundManager>
+    uintptr_t fn_get_origin;            // Get<eoc::OriginManager>
+    uintptr_t fn_get_class;             // Get<eoc::ClassDescriptions>
+    uintptr_t fn_get_progression;       // Get<eoc::ProgressionManager>
+    uintptr_t fn_get_actionresource;    // Get<eoc::ActionResourceTypes>
+    uintptr_t fn_get_template_raw;      // GlobalTemplateManager::GetTemplateRaw
+    uintptr_t fn_cache_template;        // CacheTemplateManagerBase::CacheTemplate
+
+    /* ------------------------------------------------------------------ */
+    /* Entity system                                                       */
+    /* ------------------------------------------------------------------ */
+
+    uintptr_t fn_try_get_uuid_mapping;  // ecs::legacy::Helper::TryGetSingleton<uuid::ToHandleMappingComponent>
+    uintptr_t fn_storage_tryget;        // ecs::EntityStorageContainer::TryGet(EntityHandle)
+    uintptr_t fn_spell_proto_init;      // eoc::SpellPrototype::Init(FixedString const&)
+    uintptr_t component_data_shift;     // uniform delta added to component TypeId data addresses
+                                        // (also applied to the prototype-manager singleton
+                                        //  pointers in prototype_managers.c)
+                                        // (0 for the baseline version; nonzero when the
+                                        //  __DATA segment shifted, e.g. +0x8000 for 7209685)
+} VersionOffsets;
+
+/**
+ * Initialize the offset table using the already-detected game version.
+ * Must be called after version_detect_init().
+ */
+void offset_table_init(void);
+
+/**
+ * Return offsets for the running game version, or NULL if the version is not
+ * in the table (caller should fall back to degraded mode).
+ */
+const VersionOffsets *offset_table_get(void);
+
+/**
+ * Resolve a singleton offset to a runtime address.
+ * Returns NULL if binary_base is unknown or the offset is 0.
+ *
+ * Usage:
+ *   void **ptr = (void **)offset_table_resolve(off->rpgstats_ptr);
+ *   if (ptr) stats = *ptr;
+ */
+void *offset_table_resolve(uintptr_t offset);
+
+/**
+ * Resolve a function offset to a callable pointer.
+ * Returns NULL if binary_base is unknown or the offset is 0.
+ *
+ * Usage:
+ *   typedef void (*FnType)(void);
+ *   FnType fn = (FnType)offset_table_fn(off->fn_feat_getfeats);
+ */
+void *offset_table_fn(uintptr_t offset);
+
+/**
+ * Remap a hardcoded 6995620 game-function Ghidra address to the correct address
+ * for the running version. Returns the input unchanged on the baseline/unknown
+ * version; the verified equivalent on a shifted version; or 0 if the function is
+ * not in the remap table for a shifted version (caller should then disable that
+ * feature rather than call a stale address). Input/output are full Ghidra
+ * addresses (>= 0x100000000).
+ */
+uint64_t offset_table_remap_fn(uint64_t ghidra_addr_6995620);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OFFSET_TABLE_H */

--- a/src/core/offset_table.h
+++ b/src/core/offset_table.h
@@ -40,6 +40,10 @@ typedef struct {
     uintptr_t level_cache_mgr_ptr;      // Level::s_CacheTemplateManager
     uintptr_t staticdata_mstate_ptr;    // ImmutableDataHeadmaster::m_State
     uintptr_t gst_ptr;                  // ls::gGlobalStringTable (FixedString pool)
+    uintptr_t global_switches_ptr;      // EoCGlobalSwitches* slot (double pointer).
+                                        // NOT covered by component_data_shift: this
+                                        // __common slot moved -0x24000 between 6995620
+                                        // and 7209685, breaking the uniform-shift rule.
 
     /* ------------------------------------------------------------------ */
     /* Function offsets                                                    */
@@ -63,11 +67,14 @@ typedef struct {
     uintptr_t fn_try_get_uuid_mapping;  // ecs::legacy::Helper::TryGetSingleton<uuid::ToHandleMappingComponent>
     uintptr_t fn_storage_tryget;        // ecs::EntityStorageContainer::TryGet(EntityHandle)
     uintptr_t fn_spell_proto_init;      // eoc::SpellPrototype::Init(FixedString const&)
-    uintptr_t component_data_shift;     // uniform delta added to component TypeId data addresses
-                                        // (also applied to the prototype-manager singleton
-                                        //  pointers in prototype_managers.c)
-                                        // (0 for the baseline version; nonzero when the
-                                        //  __DATA segment shifted, e.g. +0x8000 for 7209685)
+    intptr_t component_data_shift;      // signed delta added to compiled-in __DATA Ghidra
+                                        // addresses (TypeIds, prototype-manager singletons,
+                                        // TranslatedStringRepository::m_ptr) to reach THIS
+                                        // version. NOT applied to global_switches_ptr —
+                                        // that slot has its own per-version field above.
+                                        // Convention: all compiled-in __DATA constants are
+                                        // 4.1.1.7209685-vintage (nm-audited), so the
+                                        // 7209685 row is 0 and 6995620 is -0x8000.
 } VersionOffsets;
 
 /**
@@ -103,14 +110,14 @@ void *offset_table_resolve(uintptr_t offset);
 void *offset_table_fn(uintptr_t offset);
 
 /**
- * Remap a hardcoded 6995620 game-function Ghidra address to the correct address
- * for the running version. Returns the input unchanged on the baseline/unknown
- * version; the verified equivalent on a shifted version; or 0 if the function is
- * not in the remap table for a shifted version (caller should then disable that
- * feature rather than call a stale address). Input/output are full Ghidra
- * addresses (>= 0x100000000).
+ * Remap a hardcoded game-function Ghidra address (either 6995620 or 7209685
+ * vintage — the table matches both columns) to the correct address for the
+ * running version. Fail-closed: returns 0 when the version is unknown, when
+ * the version has no remap column, or when the address is not in the table —
+ * the caller must then disable that feature rather than call a stale address.
+ * Input/output are full Ghidra addresses (>= 0x100000000).
  */
-uint64_t offset_table_remap_fn(uint64_t ghidra_addr_6995620);
+uint64_t offset_table_remap_fn(uint64_t ghidra_addr);
 
 #ifdef __cplusplus
 }

--- a/src/core/offset_table.h
+++ b/src/core/offset_table.h
@@ -44,6 +44,11 @@ typedef struct {
                                         // NOT covered by component_data_shift: this
                                         // __common slot moved -0x24000 between 6995620
                                         // and 7209685, breaking the uniform-shift rule.
+    uintptr_t osiris_interface_ptr;     // osi::OsirisInterface global instance slot.
+                                        // No nm symbol — verified per-version by
+                                        // disassembling OsirisQuery's ADRP+LDR pair
+                                        // (see ghidra/offsets/OSIRIS_DATABASES.md).
+                                        // Used by osi_read_param_defs (main.c).
 
     /* ------------------------------------------------------------------ */
     /* Function offsets                                                    */

--- a/src/core/version_detect.c
+++ b/src/core/version_detect.c
@@ -9,6 +9,7 @@
  */
 
 #include "version_detect.h"
+#include "offset_table.h"
 #include "logging.h"
 
 #include <stdio.h>
@@ -307,6 +308,12 @@ static bool probe_sentinel_addresses(void) {
 
 void version_detect_set_binary_base(void *base) {
     g_binary_base = base;
+    // Both version string and binary base are now available — initialize offset table.
+    offset_table_init();
+}
+
+void *version_detect_get_binary_base(void) {
+    return g_binary_base;
 }
 
 bool version_detect_addresses_safe(void) {

--- a/src/core/version_detect.h
+++ b/src/core/version_detect.h
@@ -55,6 +55,12 @@ bool version_detect_matches(void);
 void version_detect_set_binary_base(void *base);
 
 /**
+ * Get the runtime base address of the main BG3 binary.
+ * Returns NULL if version_detect_set_binary_base() hasn't been called.
+ */
+void *version_detect_get_binary_base(void);
+
+/**
  * Check if address-dependent features should be enabled.
  * Returns true if:
  *   - Version matches exactly, OR

--- a/src/entity/component_lookup.c
+++ b/src/entity/component_lookup.c
@@ -8,6 +8,7 @@
 #include "component_lookup.h"
 #include "arm64_call.h"
 #include "../core/logging.h"
+#include "../core/offset_table.h"
 
 #include <string.h>
 
@@ -41,9 +42,19 @@ bool component_lookup_init(void *entityWorld, void *binaryBase) {
         return false;
     }
 
-    // Calculate runtime address of TryGet function
-    uintptr_t runtime_addr = ADDR_STORAGE_CONTAINER_TRYGET - GHIDRA_BASE_ADDRESS + (uintptr_t)binaryBase;
-    g_TryGetFnAddr = (void *)runtime_addr;
+    // Calculate runtime address of TryGet function.
+    // CRASH GUARD: source from the per-version offset table. If the running
+    // version has no verified offset (field == 0), leave g_TryGetFnAddr NULL so
+    // component_lookup_ready() is false and component access safely returns nil
+    // instead of calling a stale address (which lands in the wrong game function
+    // and faults). The hardcoded ADDR_* is only the 6995620 fallback.
+    const VersionOffsets *off = offset_table_get();
+    if (off && off->fn_storage_tryget) {
+        g_TryGetFnAddr = (void *)((uintptr_t)binaryBase + off->fn_storage_tryget);
+    } else {
+        g_TryGetFnAddr = NULL;
+        LOG_ENTITY_DEBUG("StorageContainer::TryGet disabled: no verified offset for this version");
+    }
 
     LOG_ENTITY_DEBUG("Initialized:");
     LOG_ENTITY_DEBUG("  EntityWorld: %p", g_EntityWorld);

--- a/src/entity/component_registry.c
+++ b/src/entity/component_registry.c
@@ -11,6 +11,7 @@
 #include "arm64_call.h"
 #include "entity_system.h"
 #include "../core/logging.h"
+#include "../core/offset_table.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -363,7 +364,10 @@ void *component_get_by_name(void *entityWorld, uint64_t entityHandle,
     // Strategy 2: Try direct template call if we have a known address
     // Note: On macOS, template functions are inlined so this DOES NOT WORK.
     // Keeping for potential future use if we find non-inlined templates.
-    uintptr_t ghidra_addr = component_template_lookup(componentName);
+    // Remap the hardcoded 6995620 address; on a shifted version these GetComponent<T>
+    // addresses aren't remapped (returns 0) so this dead path is skipped rather
+    // than jumping to a stale function.
+    uintptr_t ghidra_addr = (uintptr_t)offset_table_remap_fn(component_template_lookup(componentName));
     if (ghidra_addr != 0) {
         void *binary_base = entity_get_binary_base();
         if (binary_base) {

--- a/src/entity/component_typeid.c
+++ b/src/entity/component_typeid.c
@@ -11,6 +11,7 @@
 #include "entity_storage.h"  // For GHIDRA_BASE_ADDRESS
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/offset_table.h"  // For per-version component_data_shift
 
 #include <string.h>
 
@@ -306,8 +307,12 @@ bool component_typeid_read(uint64_t ghidraAddr, uint16_t *outIndex) {
     }
 
     /* Calculate runtime address
-     * Formula: runtime = ghidra - 0x100000000 + binary_base */
+     * Formula: runtime = ghidra - 0x100000000 + binary_base + per-version data shift.
+     * The TypeId globals live in __DATA, which can shift uniformly between game
+     * versions (e.g. +0x8000 for 7209685); component_data_shift carries that delta. */
     uint64_t offset = ghidraAddr - GHIDRA_BASE_ADDRESS;
+    const VersionOffsets *vo = offset_table_get();
+    if (vo) offset += vo->component_data_shift;
     mach_vm_address_t runtimeAddr = offset + (mach_vm_address_t)g_BinaryBase;
 
     /* Validate the runtime address before attempting to read */
@@ -361,8 +366,10 @@ bool component_typeid_read_pointer(uint64_t ghidraAddr, uint16_t *outIndex) {
         return false;
     }
 
-    /* Calculate runtime address of the pointer */
+    /* Calculate runtime address of the pointer (with per-version data shift) */
     uint64_t offset = ghidraAddr - GHIDRA_BASE_ADDRESS;
+    const VersionOffsets *vo = offset_table_get();
+    if (vo) offset += vo->component_data_shift;
     mach_vm_address_t ptrAddr = offset + (mach_vm_address_t)g_BinaryBase;
 
     /* Validate the pointer address */
@@ -514,7 +521,10 @@ void component_typeid_dump_to_console(void) {
         const TypeIdEntry *entry = &g_KnownTypeIds[i];
         total++;
 
-        mach_vm_address_t runtimeAddr = entry->ghidraAddr - GHIDRA_BASE_ADDRESS + (mach_vm_address_t)g_BinaryBase;
+        const VersionOffsets *vo = offset_table_get();
+        mach_vm_address_t runtimeAddr = entry->ghidraAddr - GHIDRA_BASE_ADDRESS
+                                        + (vo ? vo->component_data_shift : 0)
+                                        + (mach_vm_address_t)g_BinaryBase;
 
         // Check if address is readable
         SafeMemoryInfo info = safe_memory_check_address(runtimeAddr);
@@ -561,7 +571,10 @@ void component_typeid_dump(void) {
     for (int i = 0; g_KnownTypeIds[i].componentName != NULL; i++) {
         const TypeIdEntry *entry = &g_KnownTypeIds[i];
 
-        mach_vm_address_t runtimeAddr = entry->ghidraAddr - GHIDRA_BASE_ADDRESS + (mach_vm_address_t)g_BinaryBase;
+        const VersionOffsets *vo = offset_table_get();
+        mach_vm_address_t runtimeAddr = entry->ghidraAddr - GHIDRA_BASE_ADDRESS
+                                        + (vo ? vo->component_data_shift : 0)
+                                        + (mach_vm_address_t)g_BinaryBase;
 
         LOG_ENTITY_DEBUG("  %s:", entry->componentName);
         LOG_ENTITY_DEBUG("    Ghidra addr: 0x%llx", (unsigned long long)entry->ghidraAddr);

--- a/src/entity/component_typeid.c
+++ b/src/entity/component_typeid.c
@@ -38,90 +38,93 @@ static const TypeIdEntry g_KnownTypeIds[] = {
     // =====================================================================
     // ecl:: namespace (client components)
     // Discovered via: nm -gU "Baldur's Gate 3" | c++filt | grep TypeId
-    // Game version: 4.1.1.6995620 (macOS ARM64)
+    // Game version: 4.1.1.7209685 (macOS ARM64). Migrated 2026-07-29 from the
+    // original 6995620 addresses (+0x8000 uniform __DATA shift); 161/163
+    // entries symbol-verified against nm on the installed binary. Older
+    // versions are reached via VersionOffsets.component_data_shift.
     // =====================================================================
-    { "ecl::Character", 0x1088ab8e0, 0, false },
-    { "ecl::Item",      0x1088ab8f0, 0, false },
+    { "ecl::Character", 0x1088b38e0, 0, false },
+    { "ecl::Item",      0x1088b38f0, 0, false },
 
     // =====================================================================
     // eoc:: namespace (engine of combat)
     // =====================================================================
-    { "eoc::HealthComponent",  0x10890a360, 0, false },
-    { "eoc::StatsComponent",   0x10890b058, 0, false },
-    { "eoc::ArmorComponent",   0x108912e40, 0, false },
-    { "eoc::BaseHpComponent",  0x108907888, 0, false },
-    { "eoc::DataComponent",    0x10890b088, 0, false },
+    { "eoc::HealthComponent",  0x108912360, 0, false },
+    { "eoc::StatsComponent",   0x108913058, 0, false },
+    { "eoc::ArmorComponent",   0x10891ae40, 0, false },
+    { "eoc::BaseHpComponent",  0x10890f888, 0, false },
+    { "eoc::DataComponent",    0x108913088, 0, false },
 
     // =====================================================================
     // ls:: namespace (base Larian components)
     // =====================================================================
-    { "ls::TransformComponent", 0x108940550, 0, false },
-    { "ls::LevelComponent",     0x10893e780, 0, false },
-    { "ls::VisualComponent",    0x108940110, 0, false },
-    { "ls::PhysicsComponent",   0x10893c8e8, 0, false },
+    { "ls::TransformComponent", 0x108948550, 0, false },
+    { "ls::LevelComponent",     0x108946780, 0, false },
+    { "ls::VisualComponent",    0x108948110, 0, false },
+    { "ls::PhysicsComponent",   0x1089448e8, 0, false },
 
     // =====================================================================
     // Phase 2 Components (Issue #33)
     // =====================================================================
-    { "eoc::LevelComponent",             0x10890b068, 0, false },  // Character level (different from ls::LevelComponent)
-    { "eoc::exp::ExperienceComponent",   0x1088ef818, 0, false },
-    { "eoc::exp::AvailableLevelComponent", 0x108907918, 0, false },
-    { "eoc::PassiveComponent",           0x1089113f8, 0, false },
-    { "eoc::PassiveContainerComponent",  0x108907158, 0, false },
-    { "eoc::ResistancesComponent",       0x108910010, 0, false },
-    { "eoc::TagComponent",               0x10890b048, 0, false },
-    { "eoc::RaceComponent",              0x1089075f0, 0, false },
-    { "eoc::OriginComponent",            0x108900530, 0, false },
-    { "eoc::ClassesComponent",           0x10890b098, 0, false },
-    { "eoc::MovementComponent",          0x108909240, 0, false },
+    { "eoc::LevelComponent",             0x108913068, 0, false },  // Character level (different from ls::LevelComponent)
+    { "eoc::exp::ExperienceComponent",   0x1088f7818, 0, false },
+    { "eoc::exp::AvailableLevelComponent", 0x10890f918, 0, false },
+    { "eoc::PassiveComponent",           0x1089193f8, 0, false },
+    { "eoc::PassiveContainerComponent",  0x10890f158, 0, false },
+    { "eoc::ResistancesComponent",       0x108918010, 0, false },
+    { "eoc::TagComponent",               0x108913048, 0, false },
+    { "eoc::RaceComponent",              0x10890f5f0, 0, false },
+    { "eoc::OriginComponent",            0x108908530, 0, false },
+    { "eoc::ClassesComponent",           0x108913098, 0, false },
+    { "eoc::MovementComponent",          0x108911240, 0, false },
 
     // =====================================================================
     // Phase 2 Batch 2 Components (Issue #33)
     // =====================================================================
-    { "eoc::BackgroundComponent",        0x1089004e0, 0, false },
-    { "eoc::god::GodComponent",          0x1088faf68, 0, false },
-    { "eoc::ValueComponent",             0x1089078e8, 0, false },
-    { "eoc::TurnBasedComponent",         0x10890e9a8, 0, false },
+    { "eoc::BackgroundComponent",        0x1089084e0, 0, false },
+    { "eoc::god::GodComponent",          0x108902f68, 0, false },
+    { "eoc::ValueComponent",             0x10890f8e8, 0, false },
+    { "eoc::TurnBasedComponent",         0x1089169a8, 0, false },
 
     // =====================================================================
     // Phase 2 Batch 3 Components (Issue #33) - High-priority gameplay
     // =====================================================================
-    { "eoc::WeaponComponent",            0x108912e00, 0, false },
-    { "eoc::spell::BookComponent",       0x10890ae78, 0, false },
-    { "eoc::status::ContainerComponent", 0x1089130e0, 0, false },
-    { "eoc::inventory::ContainerComponent", 0x108908f08, 0, false },
-    { "eoc::ActionResourcesComponent",   0x10890eb08, 0, false },
+    { "eoc::WeaponComponent",            0x10891ae00, 0, false },
+    { "eoc::spell::BookComponent",       0x108912e78, 0, false },
+    { "eoc::status::ContainerComponent", 0x10891b0e0, 0, false },
+    { "eoc::inventory::ContainerComponent", 0x108910f08, 0, false },
+    { "eoc::ActionResourcesComponent",   0x108916b08, 0, false },
 
     // =====================================================================
     // Phase 2 Batch 4 Components (Issue #33) - Inventory relationships
     // =====================================================================
-    { "eoc::inventory::OwnerComponent",    0x108908ef8, 0, false },
-    { "eoc::inventory::MemberComponent",   0x1089153b0, 0, false },
-    { "eoc::inventory::IsOwnedComponent",  0x108903ca8, 0, false },
-    { "eoc::EquipableComponent",           0x1089078f8, 0, false },
+    { "eoc::inventory::OwnerComponent",    0x108910ef8, 0, false },
+    { "eoc::inventory::MemberComponent",   0x10891d3b0, 0, false },
+    { "eoc::inventory::IsOwnedComponent",  0x10890bca8, 0, false },
+    { "eoc::EquipableComponent",           0x10890f8f8, 0, false },
 
     // =====================================================================
     // Phase 2 Batch 5 Components (Issue #33) - Spell and boost components
     // =====================================================================
-    { "eoc::spell::ContainerComponent",               0x108906ce0, 0, false },
-    { "eoc::concentration::ConcentrationComponent",   0x108907450, 0, false },
-    { "eoc::BoostsContainerComponent",                0x108910000, 0, false },
-    { "eoc::DisplayNameComponent",                    0x10890ce20, 0, false },
+    { "eoc::spell::ContainerComponent",               0x10890ece0, 0, false },
+    { "eoc::concentration::ConcentrationComponent",   0x10890f450, 0, false },
+    { "eoc::BoostsContainerComponent",                0x108918000, 0, false },
+    { "eoc::DisplayNameComponent",                    0x108914e20, 0, false },
 
     // =====================================================================
     // Phase 2 Batch 6 Components (Issue #33) - Simple components
     // =====================================================================
-    { "eoc::death::StateComponent",                   0x1088f7a60, 0, false },
-    { "eoc::death::DeathTypeComponent",               0x1089027c0, 0, false },
-    { "eoc::inventory::WeightComponent",              0x1088f76d8, 0, false },
-    { "eoc::combat::ThreatRangeComponent",            0x10890b6e8, 0, false },
-    { "eoc::combat::IsInCombatComponent",             0x108912fd0, 0, false },
+    { "eoc::death::StateComponent",                   0x1088ffa60, 0, false },
+    { "eoc::death::DeathTypeComponent",               0x10890a7c0, 0, false },
+    { "eoc::inventory::WeightComponent",              0x1088ff6d8, 0, false },
+    { "eoc::combat::ThreatRangeComponent",            0x1089136e8, 0, false },
+    { "eoc::combat::IsInCombatComponent",             0x10891afd0, 0, false },
 
     // =====================================================================
     // Phase 2 Batch 7 Components (Issue #33) - Combat components
     // =====================================================================
-    { "eoc::combat::ParticipantComponent",            0x10890e9b8, 0, false },
-    { "eoc::combat::StateComponent",                  0x10890ea38, 0, false },
+    { "eoc::combat::ParticipantComponent",            0x1089169b8, 0, false },
+    { "eoc::combat::StateComponent",                  0x108916a38, 0, false },
 
     // =====================================================================
     // Phase 2 Batch 8 Components (Issue #33) - Tag components (115 total)
@@ -130,140 +133,143 @@ static const TypeIdEntry g_KnownTypeIds[] = {
     // =====================================================================
 
     // ecl:: tag components
-    { "ecl::camera::IsInSelectorModeComponent",       0x1088a4410, 0, false },
-    { "ecl::camera::SpellTrackingComponent",          0x1088ab858, 0, false },
-    { "ecl::dummy::IsCopyingFullPoseComponent",       0x1088a11f8, 0, false },
-    { "ecl::dummy::LoadedComponent",                  0x10889de20, 0, false },
+    { "ecl::camera::IsInSelectorModeComponent",       0x1088ac410, 0, false },
+    { "ecl::camera::SpellTrackingComponent",          0x1088b3858, 0, false },
+    { "ecl::dummy::IsCopyingFullPoseComponent",       0x1088a91f8, 0, false },
+    { "ecl::dummy::LoadedComponent",                  0x1088a5e20, 0, false },
 
     // eoc:: tag components
-    { "eoc::CanTriggerRandomCastsComponent",          0x1088ef2b8, 0, false },
-    { "eoc::ClientControlComponent",                  0x1089153c0, 0, false },
-    { "eoc::GravityDisabledComponent",                0x1088f8b48, 0, false },
-    { "eoc::IsInTurnBasedModeComponent",              0x10890e088, 0, false },
-    { "eoc::OffStageComponent",                       0x10890e238, 0, false },
-    { "eoc::PickingStateComponent",                   0x1088ef828, 0, false },
-    { "eoc::PlayerComponent",                         0x10890ea28, 0, false },
-    { "eoc::SimpleCharacterComponent",                0x1088f4068, 0, false },
-    { "eoc::active_roll::InProgressComponent",        0x1089017a8, 0, false },
-    { "eoc::ambush::AmbushingComponent",              0x1088dfb88, 0, false },
-    { "eoc::camp::PresenceComponent",                 0x10890c008, 0, false },
-    { "eoc::character::CharacterComponent",           0x10890e248, 0, false },
-    { "eoc::combat::DelayedFanfareComponent",         0x108912fe0, 0, false },
-    { "eoc::exp::CanLevelUpComponent",                0x1088f9ed8, 0, false },
-    { "eoc::falling::IsFallingComponent",             0x108912fa0, 0, false },
-    { "eoc::ftb::IsFtbPausedComponent",               0x1088f4a08, 0, false },
-    { "eoc::ftb::IsInFtbComponent",                   0x1088f62b0, 0, false },
-    { "eoc::heal::BlockComponent",                    0x1088e1c60, 0, false },
-    { "eoc::heal::MaxIncomingComponent",              0x1088e1c40, 0, false },
-    { "eoc::heal::MaxOutgoingComponent",              0x1088e1c50, 0, false },
-    { "eoc::improvised_weapon::CanBeWieldedComponent", 0x1088e2228, 0, false },
-    { "eoc::inventory::CanBeInComponent",             0x1088fe0e0, 0, false },
-    { "eoc::inventory::CannotBePickpocketedComponent", 0x1088fad78, 0, false },
-    { "eoc::inventory::CannotBeTakenOutComponent",    0x108902320, 0, false },
-    { "eoc::inventory::DropOnDeathBlockedComponent",  0x1088fadb8, 0, false },
-    { "eoc::inventory::IsLockedComponent",            0x108905760, 0, false },
-    { "eoc::inventory::NewItemsInsideComponent",      0x1088fa000, 0, false },
-    { "eoc::inventory::NonTradableComponent",         0x1088fad98, 0, false },
-    { "eoc::item::DestroyingComponent",               0x1088f87d0, 0, false },
-    { "eoc::item::DoorComponent",                     0x1088f8c68, 0, false },
-    { "eoc::item::ExamineDisabledComponent",          0x1088f8c88, 0, false },
-    { "eoc::item::HasMovedComponent",                 0x1088f8c58, 0, false },
-    { "eoc::item::HasOpenedComponent",                0x1088fab28, 0, false },
-    { "eoc::item::InUseComponent",                    0x1088f8c38, 0, false },
-    { "eoc::item::IsGoldComponent",                   0x1088f87f0, 0, false },
-    { "eoc::item::IsPoisonedComponent",               0x1088f8c48, 0, false },
-    { "eoc::item::ItemComponent",                     0x108914cb0, 0, false },
-    { "eoc::item::NewInInventoryComponent",           0x1088f9ff0, 0, false },
-    { "eoc::item::ShouldDestroyOnSpellCastComponent", 0x108904008, 0, false },
-    { "eoc::item_template::CanMoveComponent",         0x108903f20, 0, false },
-    { "eoc::item_template::ClimbOnComponent",         0x1088f8c18, 0, false },
-    { "eoc::item_template::DestroyedComponent",       0x108903f00, 0, false },
-    { "eoc::item_template::InteractionDisabledComponent", 0x108903f30, 0, false },
-    { "eoc::item_template::IsStoryItemComponent",     0x1088f8c78, 0, false },
-    { "eoc::item_template::LadderComponent",          0x108904b90, 0, false },
-    { "eoc::item_template::WalkOnComponent",          0x1088f8c28, 0, false },
-    { "eoc::multiplayer::HostComponent",              0x1088eb780, 0, false },
-    { "eoc::ownership::OwnedAsLootComponent",         0x1088f87e0, 0, false },
-    { "eoc::party::BlockFollowComponent",             0x1088f03c0, 0, false },
-    { "eoc::party::CurrentlyFollowingPartyComponent", 0x10890be78, 0, false },
-    { "eoc::pickup::PickUpExecutingComponent",        0x1088fdea0, 0, false },
-    { "eoc::rest::LongRestInScriptPhase",             0x1088eaa78, 0, false },
-    { "eoc::rest::ShortRestComponent",                0x108904f10, 0, false },
-    { "eoc::spell_cast::CanBeTargetedComponent",      0x1089041e8, 0, false },
-    { "eoc::status::IndicateDarknessComponent",       0x1088e7ad8, 0, false },
-    { "eoc::tadpole_tree::FullIllithidComponent",     0x1088e9108, 0, false },
-    { "eoc::tadpole_tree::HalfIllithidComponent",     0x1088e9118, 0, false },
-    { "eoc::tadpole_tree::TadpoledComponent",         0x1088e9128, 0, false },
-    { "eoc::tag::AvatarComponent",                    0x1089157a0, 0, false },
-    { "eoc::tag::HasExclamationDialogComponent",      0x1088e9648, 0, false },
-    { "eoc::tag::TraderComponent",                    0x1088fe310, 0, false },
-    { "eoc::through::CanSeeThroughComponent",         0x1088f8df8, 0, false },
-    { "eoc::through::CanShootThroughComponent",       0x1089072c8, 0, false },
-    { "eoc::through::CanWalkThroughComponent",        0x1088f8e18, 0, false },
-    { "eoc::trade::CanTradeComponent",                0x1088fe300, 0, false },
+    { "eoc::CanTriggerRandomCastsComponent",          0x1088f72b8, 0, false },
+    { "eoc::ClientControlComponent",                  0x10891d3c0, 0, false },
+    { "eoc::GravityDisabledComponent",                0x108900b48, 0, false },
+    { "eoc::IsInTurnBasedModeComponent",              0x108916088, 0, false },
+    { "eoc::OffStageComponent",                       0x108916238, 0, false },
+    { "eoc::PickingStateComponent",                   0x1088f7828, 0, false },
+    { "eoc::PlayerComponent",                         0x108916a28, 0, false },
+    { "eoc::SimpleCharacterComponent",                0x1088fc068, 0, false },
+    { "eoc::active_roll::InProgressComponent",        0x1089097a8, 0, false },
+    { "eoc::ambush::AmbushingComponent",              0x1088e7b88, 0, false },
+    { "eoc::camp::PresenceComponent",                 0x108914008, 0, false },
+    { "eoc::character::CharacterComponent",           0x108916248, 0, false },
+    { "eoc::combat::DelayedFanfareComponent",         0x10891afe0, 0, false },
+    { "eoc::exp::CanLevelUpComponent",                0x108901ed8, 0, false },
+    { "eoc::falling::IsFallingComponent",             0x10891afa0, 0, false },
+    { "eoc::ftb::IsFtbPausedComponent",               0x1088fca08, 0, false },
+    { "eoc::ftb::IsInFtbComponent",                   0x1088fe2b0, 0, false },
+    { "eoc::heal::BlockComponent",                    0x1088e9c60, 0, false },
+    { "eoc::heal::MaxIncomingComponent",              0x1088e9c40, 0, false },
+    { "eoc::heal::MaxOutgoingComponent",              0x1088e9c50, 0, false },
+    { "eoc::improvised_weapon::CanBeWieldedComponent", 0x1088ea228, 0, false },
+    { "eoc::inventory::CanBeInComponent",             0x1089060e0, 0, false },
+    { "eoc::inventory::CannotBePickpocketedComponent", 0x108902d78, 0, false },
+    { "eoc::inventory::CannotBeTakenOutComponent",    0x10890a320, 0, false },
+    { "eoc::inventory::DropOnDeathBlockedComponent",  0x108902db8, 0, false },
+    { "eoc::inventory::IsLockedComponent",            0x10890d760, 0, false },
+    { "eoc::inventory::NewItemsInsideComponent",      0x108902000, 0, false },
+    { "eoc::inventory::NonTradableComponent",         0x108902d98, 0, false },
+    { "eoc::item::DestroyingComponent",               0x1089007d0, 0, false },
+    { "eoc::item::DoorComponent",                     0x108900c68, 0, false },
+    { "eoc::item::ExamineDisabledComponent",          0x108900c88, 0, false },
+    { "eoc::item::HasMovedComponent",                 0x108900c58, 0, false },
+    { "eoc::item::HasOpenedComponent",                0x108902b28, 0, false },
+    { "eoc::item::InUseComponent",                    0x108900c38, 0, false },
+    { "eoc::item::IsGoldComponent",                   0x1089007f0, 0, false },
+    { "eoc::item::IsPoisonedComponent",               0x108900c48, 0, false },
+    { "eoc::item::ItemComponent",                     0x10891ccb0, 0, false },
+    { "eoc::item::NewInInventoryComponent",           0x108901ff0, 0, false },
+    { "eoc::item::ShouldDestroyOnSpellCastComponent", 0x10890c008, 0, false },
+    { "eoc::item_template::CanMoveComponent",         0x10890bf20, 0, false },
+    { "eoc::item_template::ClimbOnComponent",         0x108900c18, 0, false },
+    { "eoc::item_template::DestroyedComponent",       0x10890bf00, 0, false },
+    { "eoc::item_template::InteractionDisabledComponent", 0x10890bf30, 0, false },
+    { "eoc::item_template::IsStoryItemComponent",     0x108900c78, 0, false },
+    { "eoc::item_template::LadderComponent",          0x10890cb90, 0, false },
+    { "eoc::item_template::WalkOnComponent",          0x108900c28, 0, false },
+    { "eoc::multiplayer::HostComponent",              0x1088f3780, 0, false },
+    { "eoc::ownership::OwnedAsLootComponent",         0x1089007e0, 0, false },
+    { "eoc::party::BlockFollowComponent",             0x1088f83c0, 0, false },
+    { "eoc::party::CurrentlyFollowingPartyComponent", 0x108913e78, 0, false },
+    { "eoc::pickup::PickUpExecutingComponent",        0x108905ea0, 0, false },
+    { "eoc::rest::LongRestInScriptPhase",             0x1088f2a78, 0, false },
+    { "eoc::rest::ShortRestComponent",                0x10890cf10, 0, false },
+    { "eoc::spell_cast::CanBeTargetedComponent",      0x10890c1e8, 0, false },
+    { "eoc::status::IndicateDarknessComponent",       0x1088efad8, 0, false },
+    { "eoc::tadpole_tree::FullIllithidComponent",     0x1088f1108, 0, false },
+    { "eoc::tadpole_tree::HalfIllithidComponent",     0x1088f1118, 0, false },
+    { "eoc::tadpole_tree::TadpoledComponent",         0x1088f1128, 0, false },
+    { "eoc::tag::AvatarComponent",                    0x10891d7a0, 0, false },
+    { "eoc::tag::HasExclamationDialogComponent",      0x1088f1648, 0, false },
+    { "eoc::tag::TraderComponent",                    0x108906310, 0, false },
+    { "eoc::through::CanSeeThroughComponent",         0x108900df8, 0, false },
+    { "eoc::through::CanShootThroughComponent",       0x10890f2c8, 0, false },
+    { "eoc::through::CanWalkThroughComponent",        0x108900e18, 0, false },
+    { "eoc::trade::CanTradeComponent",                0x108906300, 0, false },
 
     // esv:: tag components
-    { "esv::IsMarkedForDeletionComponent",            0x1088fd0d8, 0, false },
-    { "esv::NetComponent",                            0x1088f6c90, 0, false },
-    { "esv::ScriptPropertyCanBePickpocketedComponent", 0x1088dff30, 0, false },
-    { "esv::ScriptPropertyIsDroppedOnDeathComponent", 0x1088e2420, 0, false },
-    { "esv::ScriptPropertyIsTradableComponent",       0x1088e24f0, 0, false },
-    { "esv::TurnOrderSkippedComponent",               0x10890ead8, 0, false },
-    { "esv::VariableManagerComponent",                0x1088eb928, 0, false },
-    { "esv::boost::StatusBoostsProcessedComponent",   0x108903e48, 0, false },
-    { "esv::character_creation::IsCustomComponent",   0x1088f69e8, 0, false },
-    { "esv::combat::CanStartCombatComponent",         0x1088f1670, 0, false },
-    { "esv::combat::FleeBlockedComponent",            0x1088f0e80, 0, false },
-    { "esv::combat::ImmediateJoinComponent",          0x1088f15c0, 0, false },
-    { "esv::combat::LeaveRequestComponent",           0x1088f4858, 0, false },
-    { "esv::cover::IsLightBlockerComponent",          0x1088e0498, 0, false },
-    { "esv::cover::IsVisionBlockerComponent",         0x1088eb9b0, 0, false },
-    { "esv::darkness::DarknessActiveComponent",       0x1088e05e8, 0, false },
-    { "esv::death::DeathContinueComponent",           0x1088f04c0, 0, false },
-    { "esv::escort::HasStragglersComponent",          0x1088e14b0, 0, false },
-    { "esv::hotbar::OrderComponent",                  0x1088e4528, 0, false },
-    { "esv::inventory::CharacterHasGeneratedTradeTreasureComponent", 0x1088f7a80, 0, false },
-    { "esv::inventory::EntityHasGeneratedTreasureComponent", 0x1088f7a70, 0, false },
-    { "esv::inventory::IsReplicatedWithComponent",    0x1088f6e30, 0, false },
-    { "esv::inventory::ReadyToBeAddedToInventoryComponent", 0x1088f6b10, 0, false },
-    { "esv::level::InventoryItemDataPopulatedComponent", 0x1088e2ae8, 0, false },
-    { "esv::rest::ShortRestConsumeResourcesComponent", 0x1088ec6c0, 0, false },
-    { "esv::sight::EventsEnabledComponent",           0x1088eb960, 0, false },
-    { "esv::spell_cast::ClientInitiatedComponent",    0x108905a90, 0, false },
-    { "esv::status::ActiveComponent",                 0x1088fd058, 0, false },
-    { "esv::status::AddedFromSaveLoadComponent",      0x108902400, 0, false },
-    { "esv::status::AuraComponent",                   0x1088e8000, 0, false },
-    { "esv::summon::IsUnsummoningComponent",          0x1088f8ae8, 0, false },
-    { "esv::trigger::LoadedHandledComponent",         0x1088ea2a8, 0, false },
-    { "esv::trigger::TriggerWorldAutoTriggeredComponent", 0x10890bea8, 0, false },
+    { "esv::IsMarkedForDeletionComponent",            0x1089050d8, 0, false },
+    { "esv::NetComponent",                            0x1088fec90, 0, false },
+    { "esv::ScriptPropertyCanBePickpocketedComponent", 0x1088e7f30, 0, false },
+    { "esv::ScriptPropertyIsDroppedOnDeathComponent", 0x1088ea420, 0, false },
+    { "esv::ScriptPropertyIsTradableComponent",       0x1088ea4f0, 0, false },
+    { "esv::TurnOrderSkippedComponent",               0x108916ad8, 0, false },
+    { "esv::VariableManagerComponent",                0x1088f3928, 0, false },
+    { "esv::boost::StatusBoostsProcessedComponent",   0x10890be48, 0, false },
+    { "esv::character_creation::IsCustomComponent",   0x1088fe9e8, 0, false },
+    { "esv::combat::CanStartCombatComponent",         0x1088f9670, 0, false },
+    { "esv::combat::FleeBlockedComponent",            0x1088f8e80, 0, false },
+    { "esv::combat::ImmediateJoinComponent",          0x1088f95c0, 0, false },
+    { "esv::combat::LeaveRequestComponent",           0x1088fc858, 0, false },
+    { "esv::cover::IsLightBlockerComponent",          0x1088e8498, 0, false },
+    { "esv::cover::IsVisionBlockerComponent",         0x1088f39b0, 0, false },
+    { "esv::darkness::DarknessActiveComponent",       0x1088e85e8, 0, false },
+    { "esv::death::DeathContinueComponent",           0x1088f84c0, 0, false },
+    { "esv::escort::HasStragglersComponent",          0x1088e94b0, 0, false },
+    { "esv::hotbar::OrderComponent",                  0x1088ec528, 0, false },
+    { "esv::inventory::CharacterHasGeneratedTradeTreasureComponent", 0x1088ffa80, 0, false },
+    { "esv::inventory::EntityHasGeneratedTreasureComponent", 0x1088ffa70, 0, false },
+    { "esv::inventory::IsReplicatedWithComponent",    0x1088fee30, 0, false },
+    { "esv::inventory::ReadyToBeAddedToInventoryComponent", 0x1088feb10, 0, false },
+    { "esv::level::InventoryItemDataPopulatedComponent", 0x1088eaae8, 0, false },
+    { "esv::rest::ShortRestConsumeResourcesComponent", 0x1088f46c0, 0, false },
+    { "esv::sight::EventsEnabledComponent",           0x1088f3960, 0, false },
+    { "esv::spell_cast::ClientInitiatedComponent",    0x10890da90, 0, false },
+    { "esv::status::ActiveComponent",                 0x108905058, 0, false },
+    { "esv::status::AddedFromSaveLoadComponent",      0x10890a400, 0, false },
+    { "esv::status::AuraComponent",                   0x1088f0000, 0, false },
+    { "esv::summon::IsUnsummoningComponent",          0x108900ae8, 0, false },
+    { "esv::trigger::LoadedHandledComponent",         0x1088f22a8, 0, false },
+    { "esv::trigger::TriggerWorldAutoTriggeredComponent", 0x108913ea8, 0, false },
 
     // =====================================================================
     // Template Components (Issue #41 - Ext.Template support)
     // =====================================================================
-    { "eoc::templates::OriginalTemplateComponent",    0x108902230, 0, false },
+    { "eoc::templates::OriginalTemplateComponent",    0x10890a230, 0, false },
 
     // ls:: tag components
-    { "ls::AlwaysUpdateEffectComponent",              0x1089363d8, 0, false },
-    { "ls::AnimationUpdateComponent",                 0x108935e68, 0, false },
-    { "ls::IsGlobalComponent",                        0x10893f0c0, 0, false },
-    { "ls::IsSeeThroughComponent",                    0x10893d628, 0, false },
-    { "ls::LevelIsOwnerComponent",                    0x10893b1a8, 0, false },
-    { "ls::LevelPrepareUnloadBusyComponent",          0x108935ed8, 0, false },
-    { "ls::LevelUnloadBusyComponent",                 0x10893b448, 0, false },
-    { "ls::SavegameComponent",                        0x108935ff8, 0, false },
-    { "ls::VisualLoadedComponent",                    0x1089402a8, 0, false },
-    { "ls::game::PauseComponent",                     0x10893e8f0, 0, false },
-    { "ls::game::PauseExcludedComponent",             0x10893e930, 0, false },
-    { "ls::level::LevelInstanceUnloadingComponent",   0x10893b468, 0, false },
+    { "ls::AlwaysUpdateEffectComponent",              0x10893e3d8, 0, false },
+    { "ls::AnimationUpdateComponent",                 0x10893de68, 0, false },
+    { "ls::IsGlobalComponent",                        0x1089470c0, 0, false },
+    { "ls::IsSeeThroughComponent",                    0x108945628, 0, false },
+    { "ls::LevelIsOwnerComponent",                    0x1089431a8, 0, false },
+    { "ls::LevelPrepareUnloadBusyComponent",          0x10893ded8, 0, false },
+    { "ls::LevelUnloadBusyComponent",                 0x108943448, 0, false },
+    { "ls::SavegameComponent",                        0x10893dff8, 0, false },
+    { "ls::VisualLoadedComponent",                    0x1089482a8, 0, false },
+    { "ls::game::PauseComponent",                     0x1089468f0, 0, false },
+    { "ls::game::PauseExcludedComponent",             0x108946930, 0, false },
+    { "ls::level::LevelInstanceUnloadingComponent",   0x108943468, 0, false },
 
     // =====================================================================
     // Issue #51 Event Components - One-frame event components for Ext.Events
     // These addresses contain POINTERS to TypeIndex storage.
     // Must dereference: TypeIndex = *(uint32_t*)(*ptr)
     // Discovered via Ghidra: RegisterQueryDescription uses PTR_m_TypeIndex pattern.
+    // PTR_ slots live in __DATA_CONST (no nm symbol); +0x8000 migration relies on
+    // the segment-wide shift proven by the __got slot at 0x1083cca68. Reads are
+    // safe_memory-validated and range-checked, so a miss degrades, not crashes.
     // =====================================================================
-    { "esv::TurnStartedEventOneFrameComponent",       0x1083ced18, 0, false, true },  // TypeIndex 167
-    { "esv::TurnEndedEventOneFrameComponent",         0x1083ceca8, 0, false, true },  // TypeIndex 164
+    { "esv::TurnStartedEventOneFrameComponent",       0x1083d6d18, 0, false, true },  // TypeIndex 167
+    { "esv::TurnEndedEventOneFrameComponent",         0x1083d6ca8, 0, false, true },  // TypeIndex 164
 
     // Sentinel
     { NULL, 0, 0, false, false }

--- a/src/entity/entity_system.c
+++ b/src/entity/entity_system.c
@@ -14,6 +14,7 @@
 #include "arm64_call.h"
 #include "logging.h"
 #include "../core/version_detect.h"
+#include "../core/offset_table.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -463,10 +464,20 @@ static void *read_eocserver_from_global(void) {
         return NULL;
     }
 
-    // Calculate runtime address of esv::EocServer::m_ptr
+    // Calculate runtime address of esv::EocServer::m_ptr.
+    // Prefer the per-version offset table (eocserver_ptr); fall back to the
+    // hardcoded 6995620 address only if the version is unknown. Using the stale
+    // hardcoded value on a shifted version reads the wrong slot -> garbage
+    // EoCServer -> garbage EntityWorld -> crash inside the ECS query.
     uintptr_t ghidra_base = GHIDRA_BASE_ADDRESS;
     uintptr_t actual_base = (uintptr_t)g_MainBinaryBase;
-    uintptr_t global_addr = OFFSET_EOCSERVER_SINGLETON_PTR - ghidra_base + actual_base;
+    uintptr_t global_addr;
+    const VersionOffsets *off = offset_table_get();
+    if (off && off->eocserver_ptr) {
+        global_addr = actual_base + off->eocserver_ptr;
+    } else {
+        global_addr = OFFSET_EOCSERVER_SINGLETON_PTR - ghidra_base + actual_base;
+    }
 
     LOG_ENTITY_DEBUG("Reading EoCServer from global at 0x%llx", (unsigned long long)global_addr);
     LOG_ENTITY_DEBUG("  (Ghidra offset: 0x%llx, base: %p)",
@@ -1005,9 +1016,22 @@ int entity_system_init(void *main_binary_base) {
     LOG_ENTITY_DEBUG("Main binary hooks disabled (macOS memory protection issues)");
     LOG_ENTITY_DEBUG("EntityWorld must be set manually via Ext.Entity.SetWorldPtr() or discovered via Osiris hooks");
 
-    // Set up function pointers for component accessors and singleton getters
-    // These don't need hooks - we just need to know where to call
-    g_TryGetUuidMappingSingleton = (TryGetSingletonFn)(OFFSET_TRY_GET_UUID_MAPPING_SINGLETON - ghidra_base + actual_base);
+    // Set up function pointers for component accessors and singleton getters.
+    // CRASH GUARD: source the UUID-mapping singleton getter from the per-version
+    // offset table. If the running version has no *verified* offset (field == 0),
+    // the pointer stays NULL and entity_get_by_guid safely no-ops instead of
+    // calling a stale address (which is valid-but-wrong code and would crash).
+    // The hardcoded OFFSET_* below is only the 6995620 fallback.
+    {
+        const VersionOffsets *off = offset_table_get();
+        if (off && off->fn_try_get_uuid_mapping) {
+            g_TryGetUuidMappingSingleton =
+                (TryGetSingletonFn)offset_table_fn(off->fn_try_get_uuid_mapping);
+        } else {
+            g_TryGetUuidMappingSingleton = NULL;
+            LOG_ENTITY_DEBUG("UUID-mapping getter disabled: no verified offset for this version");
+        }
+    }
 
     // ls:: components - all DISABLED until addresses are verified via Ghidra
     // When offset is 0, pointer stays NULL (safe)

--- a/src/entity/entity_system.c
+++ b/src/entity/entity_system.c
@@ -465,18 +465,23 @@ static void *read_eocserver_from_global(void) {
     }
 
     // Calculate runtime address of esv::EocServer::m_ptr.
-    // Prefer the per-version offset table (eocserver_ptr); fall back to the
-    // hardcoded 6995620 address only if the version is unknown. Using the stale
-    // hardcoded value on a shifted version reads the wrong slot -> garbage
-    // EoCServer -> garbage EntityWorld -> crash inside the ECS query.
+    // Prefer the per-version offset table (eocserver_ptr). The hardcoded define
+    // is allowed only when the binary is the exact build it was audited against
+    // (version_detect_matches()); on any other version reading a stale slot
+    // yields a garbage EoCServer -> garbage EntityWorld -> crash inside the ECS
+    // query, so we fail closed instead.
     uintptr_t ghidra_base = GHIDRA_BASE_ADDRESS;
     uintptr_t actual_base = (uintptr_t)g_MainBinaryBase;
     uintptr_t global_addr;
     const VersionOffsets *off = offset_table_get();
     if (off && off->eocserver_ptr) {
         global_addr = actual_base + off->eocserver_ptr;
-    } else {
+    } else if (version_detect_matches()) {
         global_addr = OFFSET_EOCSERVER_SINGLETON_PTR - ghidra_base + actual_base;
+    } else {
+        LOG_ENTITY_DEBUG("No verified EocServer slot for this game version — "
+                         "entity capture via global disabled (fail closed)");
+        return NULL;
     }
 
     LOG_ENTITY_DEBUG("Reading EoCServer from global at 0x%llx", (unsigned long long)global_addr);

--- a/src/enum/enum_definitions.c
+++ b/src/enum/enum_definitions.c
@@ -400,6 +400,78 @@ static void register_damage_flags(void) {
 }
 
 // ============================================================================
+// ClientGameState (ecl::GameState — Enumerations/Engine.inl)
+// ============================================================================
+// Required by the GameStateChanged event and Ext.Utils.GetGameState: mods
+// (MCM's IsMainMenu gate among them) compare event states against
+// Ext.Enums.ClientGameState.X with ==.
+static void register_client_game_state(void) {
+    int idx = enum_registry_add_type("ClientGameState", false);
+    if (idx < 0) return;
+
+    REG_VALUE(idx, "Unknown", 0);
+    REG_VALUE(idx, "Init", 1);
+    REG_VALUE(idx, "InitMenu", 2);
+    REG_VALUE(idx, "InitNetwork", 3);
+    REG_VALUE(idx, "InitConnection", 4);
+    REG_VALUE(idx, "Idle", 5);
+    REG_VALUE(idx, "LoadMenu", 6);
+    REG_VALUE(idx, "Menu", 7);
+    REG_VALUE(idx, "Exit", 8);
+    REG_VALUE(idx, "SwapLevel", 9);
+    REG_VALUE(idx, "LoadLevel", 10);
+    REG_VALUE(idx, "LoadModule", 11);
+    REG_VALUE(idx, "LoadSession", 12);
+    REG_VALUE(idx, "UnloadLevel", 13);
+    REG_VALUE(idx, "UnloadModule", 14);
+    REG_VALUE(idx, "UnloadSession", 15);
+    REG_VALUE(idx, "Paused", 16);
+    REG_VALUE(idx, "PrepareRunning", 17);
+    REG_VALUE(idx, "Running", 18);
+    REG_VALUE(idx, "Disconnect", 19);
+    REG_VALUE(idx, "Join", 20);
+    REG_VALUE(idx, "Save", 21);
+    REG_VALUE(idx, "StartLoading", 22);
+    REG_VALUE(idx, "StopLoading", 23);
+    REG_VALUE(idx, "StartServer", 24);
+    REG_VALUE(idx, "Movie", 25);
+    REG_VALUE(idx, "Installation", 26);
+    REG_VALUE(idx, "ModReceiving", 27);
+    REG_VALUE(idx, "Lobby", 28);
+    REG_VALUE(idx, "BuildStory", 29);
+    REG_VALUE(idx, "GeneratePsoCache", 32);
+    REG_VALUE(idx, "LoadPsoCache", 33);
+    REG_VALUE(idx, "AnalyticsSessionEnd", 34);
+}
+
+// ============================================================================
+// ServerGameState (esv::GameState — Enumerations/Engine.inl)
+// ============================================================================
+static void register_server_game_state(void) {
+    int idx = enum_registry_add_type("ServerGameState", false);
+    if (idx < 0) return;
+
+    REG_VALUE(idx, "Unknown", 0);
+    REG_VALUE(idx, "Uninitialized", 1);
+    REG_VALUE(idx, "Init", 2);
+    REG_VALUE(idx, "Idle", 3);
+    REG_VALUE(idx, "Exit", 4);
+    REG_VALUE(idx, "LoadLevel", 5);
+    REG_VALUE(idx, "LoadModule", 6);
+    REG_VALUE(idx, "LoadSession", 7);
+    REG_VALUE(idx, "UnloadLevel", 8);
+    REG_VALUE(idx, "UnloadModule", 9);
+    REG_VALUE(idx, "UnloadSession", 10);
+    REG_VALUE(idx, "Sync", 11);
+    REG_VALUE(idx, "Paused", 12);
+    REG_VALUE(idx, "Running", 13);
+    REG_VALUE(idx, "Save", 14);
+    REG_VALUE(idx, "Disconnect", 15);
+    REG_VALUE(idx, "BuildStory", 16);
+    REG_VALUE(idx, "ReloadStory", 17);
+}
+
+// ============================================================================
 // Public API
 // ============================================================================
 void enum_register_definitions(void) {
@@ -415,6 +487,8 @@ void enum_register_definitions(void) {
     register_item_slot();
     register_item_rarity();
     register_spell_type();
+    register_client_game_state();
+    register_server_game_state();
 
     // Bitfields
     register_attribute_flags();

--- a/src/game/global_switches.c
+++ b/src/game/global_switches.c
@@ -1,6 +1,7 @@
 #include "global_switches.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/offset_table.h"
 #include <dispatch/dispatch.h>
 #include <mach-o/dyld.h>
 #include <string.h>
@@ -36,7 +37,12 @@ bool global_switches_init(void) {
     }
 
     uintptr_t slide = base - 0x100000000;
-    uintptr_t ptr_addr = GLOBAL_SWITCHES_PTR_VA + slide;
+    // The switches pointer slot is a __DATA global -> apply the per-version data
+    // shift. This read is safe (safe_memory_read_pointer), so a wrong address
+    // just fails gracefully rather than crashing.
+    const VersionOffsets *vo = offset_table_get();
+    uintptr_t data_shift = vo ? vo->component_data_shift : 0;
+    uintptr_t ptr_addr = GLOBAL_SWITCHES_PTR_VA + slide + data_shift;
 
     void *ptr_val = NULL;
     if (!safe_memory_read_pointer((mach_vm_address_t)ptr_addr, &ptr_val)) {

--- a/src/game/global_switches.c
+++ b/src/game/global_switches.c
@@ -6,12 +6,15 @@
 #include <mach-o/dyld.h>
 #include <string.h>
 
-// GlobalSwitches singleton: double pointer at this VA
-// Found via RE: VMGameData init loads from ADRP 0x108b18000 + LDR [x20, #0xf30]
-#define GLOBAL_SWITCHES_PTR_VA 0x108b18f30
+// The GlobalSwitches singleton slot (double pointer) is per-version:
+// VersionOffsets.global_switches_ptr. It does NOT follow the uniform __DATA
+// shift (moved -0x24000 between 6995620 and 7209685), so it must never be
+// derived via component_data_shift.
 
 // SkipSplashScreen field offset within EoCGlobalSwitches struct (ARM64 macOS)
-// Found via RE: LDRB w8, [x8, #0x6ac] after SkipSplashScreen property registration
+// Found via RE: LDRB w8, [x8, #0x6ac] after SkipSplashScreen property registration.
+// Re-verified on 7209685 (2026-07-29): ldr xN,[slot] ; ldrb/strb [xN, #0x6ac]
+// appears at multiple sites, including a toggle (eor #1) sequence.
 #define OFFSET_SKIP_SPLASH_SCREEN 0x6ac
 
 static void *s_global_switches = NULL;
@@ -36,13 +39,13 @@ bool global_switches_init(void) {
         return false;
     }
 
-    uintptr_t slide = base - 0x100000000;
-    // The switches pointer slot is a __DATA global -> apply the per-version data
-    // shift. This read is safe (safe_memory_read_pointer), so a wrong address
-    // just fails gracefully rather than crashing.
+    // Fail closed: no table row for this version -> feature disabled.
     const VersionOffsets *vo = offset_table_get();
-    uintptr_t data_shift = vo ? vo->component_data_shift : 0;
-    uintptr_t ptr_addr = GLOBAL_SWITCHES_PTR_VA + slide + data_shift;
+    if (!vo || !vo->global_switches_ptr) {
+        LOG_CORE_INFO("[GlobalSwitches] No verified slot for this game version — disabled");
+        return false;
+    }
+    uintptr_t ptr_addr = base + vo->global_switches_ptr;
 
     void *ptr_val = NULL;
     if (!safe_memory_read_pointer((mach_vm_address_t)ptr_addr, &ptr_val)) {
@@ -57,8 +60,8 @@ bool global_switches_init(void) {
 
     s_global_switches = ptr_val;
     s_initialized = true;
-    LOG_CORE_INFO("[GlobalSwitches] Found singleton at 0x%lx (slide=0x%lx)",
-                  (unsigned long)s_global_switches, (unsigned long)slide);
+    LOG_CORE_INFO("[GlobalSwitches] Found singleton at 0x%lx (base=0x%lx)",
+                  (unsigned long)s_global_switches, (unsigned long)base);
     return true;
 }
 
@@ -66,6 +69,17 @@ bool global_switches_set_skip_splash_screen(bool value) {
     if (!s_global_switches && !global_switches_init()) return false;
 
     uint8_t *field = (uint8_t *)s_global_switches + OFFSET_SKIP_SPLASH_SCREEN;
+
+    // Read-back guard before the raw write: the field must be readable and
+    // already hold a bool (0/1). Anything else means the pointer or struct
+    // layout is wrong for this build — refuse to write.
+    uint8_t current = 0xFF;
+    if (!safe_memory_read((mach_vm_address_t)field, &current, 1) || current > 1) {
+        LOG_CORE_ERROR("[GlobalSwitches] Sanity check failed at %p (+0x%x, val=0x%x) — refusing write",
+                       (void *)field, OFFSET_SKIP_SPLASH_SCREEN, current);
+        return false;
+    }
+
     *field = value ? 1 : 0;
     LOG_CORE_INFO("[GlobalSwitches] SkipSplashScreen = %s (at 0x%lx + 0x%x)",
                   value ? "true" : "false",

--- a/src/injector/main.c
+++ b/src/injector/main.c
@@ -57,6 +57,8 @@ extern "C" {
 #include "osiris_functions.h"
 #include "custom_functions.h"
 #include "pattern_scan.h"
+#include "safe_memory.h"
+#include "offset_table.h"
 
 // PAK file reading
 #include "pak_reader.h"
@@ -175,6 +177,8 @@ static OsiArgumentDesc *alloc_args(int count);
 static void set_arg_string(OsiArgumentDesc *arg, const char *value, int isGuid);
 static void set_arg_int(OsiArgumentDesc *arg, int32_t value);
 static void set_arg_real(OsiArgumentDesc *arg, float value);
+typedef struct { uint32_t type; uint8_t direction; } OsiParamDef;
+static int osi_read_param_defs(uint32_t handle, OsiParamDef *defs, int maxDefs);
 static int osiris_query_by_id(uint32_t funcId, OsiArgumentDesc *args);
 static int osi_value_to_lua(lua_State *L, OsiArgumentValue *val);
 static int osi_is_tagged(const char *character, const char *tag);
@@ -1021,6 +1025,9 @@ static int lua_gethostcharacter(lua_State *L) {
  * Osi.IsTagged(character, tag) - Check if character has a tag
  * Uses real Osiris query when available, falls back to heuristics
  */
+// Retained for reference/fallback only; Osi.IsTagged now routes through the
+// generic dynamic dispatcher (see register_osi_namespace). Not currently bound.
+__attribute__((unused))
 static int lua_osi_istagged(lua_State *L) {
     const char *character = luaL_checkstring(L, 1);
     const char *tag = luaL_checkstring(L, 2);
@@ -1238,6 +1245,180 @@ static int lua_entity_get_discovered_players(lua_State *L) {
 // ============================================================================
 
 /**
+ * Resolve an Osiris COsiStringHandle to its C string, replicating
+ * COsiStringTable::GetStr (libOsiris arm64 @ 0x39c30) read-only:
+ *   index = handle & 0x1FFFFF;  (0 => empty string)
+ *   table = *(base+0x96cb8);  str = *( *( *(table) + 0x28 ) + index*32 )
+ * 0x96cb8 is the exported _OsiStringTable global (dlsym-able if libOsiris
+ * ever changes). Fills buf; returns 1 on success (incl. the empty case).
+ */
+static int osi_resolve_string_handle(uint64_t handle, char *buf, size_t bufsz) {
+    if (bufsz == 0) return 0;
+    uint64_t index = handle & 0x1FFFFF;
+    if (index == 0) { buf[0] = '\0'; return 1; }   /* handle 0 => "" */
+    if (!g_pOsiFunctionMan) return 0;
+    uintptr_t base = (uintptr_t)g_pOsiFunctionMan - 0x9f348;
+    void *tableObj = NULL, *sub = NULL, *arr = NULL, *strPtr = NULL;
+    if (!safe_memory_read_pointer((mach_vm_address_t)(base + 0x96cb8), &tableObj) || !tableObj) return 0;
+    if (!safe_memory_read_pointer((mach_vm_address_t)tableObj, &sub) || !sub) return 0;
+    if (!safe_memory_read_pointer((mach_vm_address_t)sub + 0x28, &arr) || !arr) return 0;
+    if (!safe_memory_read_pointer((mach_vm_address_t)arr + (mach_vm_address_t)index * 32, &strPtr) || !strPtr) return 0;
+    return safe_memory_read_string((mach_vm_address_t)strPtr, buf, bufsz) ? 1 : 0;
+}
+
+/**
+ * Push one Osiris COsiTypedValue (16 bytes) as a Lua value.
+ * Layout (RE'd from libOsiris Compare/COsiTypedValueBase ctor): value @ tv+0x00
+ * (8 bytes), typeId (u16) @ tv+0x08. INTEGER/INTEGER64 store the integer inline;
+ * REAL stores a float; STRING/GUIDSTRING and custom GUID subtypes store a
+ * COsiStringHandle (resolved via the string table), NOT a raw char*.
+ */
+static void osi_push_typed_value(lua_State *L, mach_vm_address_t tv) {
+    uint16_t typeId = 0;
+    safe_memory_read(tv + 0x08, &typeId, sizeof(typeId));
+    if (typeId == OSI_TYPE_INTEGER) {
+        uint32_t v = 0; safe_memory_read_u32(tv, &v);
+        lua_pushinteger(L, (lua_Integer)(int32_t)v);
+    } else if (typeId == OSI_TYPE_INTEGER64) {
+        uint64_t v = 0; safe_memory_read_u64(tv, &v);
+        lua_pushinteger(L, (lua_Integer)(int64_t)v);
+    } else if (typeId == OSI_TYPE_REAL) {
+        uint32_t v = 0; safe_memory_read_u32(tv, &v);
+        float f; memcpy(&f, &v, sizeof(f));
+        lua_pushnumber(L, (lua_Number)f);
+    } else {
+        uint64_t handle = 0;
+        char buf[256];
+        safe_memory_read_u64(tv, &handle);
+        if (osi_resolve_string_handle(handle, buf, sizeof(buf))) {
+            lua_pushstring(L, buf);
+        } else {
+            lua_pushstring(L, "");
+        }
+    }
+}
+
+/**
+ * Read all rows of an Osiris database directly from its CReteDBase Facts list,
+ * the way Windows BG3SE does. Databases have OsiFunctionId==0 and cannot be
+ * dispatched via InternalQuery, so we resolve def -> node -> CReteDBase and walk
+ * its std::list<CTuple>. `def` is the COsiFunctionData* from the name index
+ * (osi_db_lookup). Filter args are on the Lua stack at 2..N (nil = wildcard,
+ * matching Osiris column order). Pushes a result table (array of row tables).
+ *
+ * Chain (RE'd from libOsiris — see ghidra/offsets/OSIRIS_DATABASES.md; the
+ * factory/dbmgr globals are the exported _ReteNodeFactory/_ReteDBaseFactory):
+ *   nodeId = *(def+0x20); factory = *(base+0x9f338);
+ *   node   = *( *(factory+0x08) + (nodeId-1)*8 ); dbId = *(node+0x18);
+ *   dbmgr  = *(base+0x9f5b0);  db = *( *(dbmgr+0x08) + (dbId-1)*8 ) (CReteDBase);
+ *   colCount = *(db+0x40); facts list @ db+0x10 sentinel, begin=*(db+0x18),
+ *   node.next @ +0x08, CTuple @ node+0x10, CTuple.values = *(CTuple+0x00),
+ *   column i COsiTypedValue @ values + i*0x10.
+ */
+static int osi_db_read_facts(lua_State *L, void *def) {
+    int nfilter = lua_gettop(L) - 1;      /* filter args at stack 2..top */
+    if (nfilter < 0) nfilter = 0;
+
+    lua_newtable(L);                       /* result table (always returned) */
+    int resultIdx = lua_gettop(L);
+    int rowCount = 0;
+
+    if (!def || !g_pOsiFunctionMan) return 1;
+    uintptr_t base = (uintptr_t)g_pOsiFunctionMan - 0x9f348;
+
+    void *factory = NULL, *dbmgr = NULL;
+    if (!safe_memory_read_pointer((mach_vm_address_t)(base + 0x9f338), &factory) || !factory) return 1;
+    if (!safe_memory_read_pointer((mach_vm_address_t)(base + 0x9f5b0), &dbmgr) || !dbmgr) return 1;
+
+    uint32_t nodeId = 0;
+    if (!safe_memory_read_u32((mach_vm_address_t)def + 0x20, &nodeId) || nodeId == 0) return 1;
+
+    /* def -> node via node factory vector (id-1 index; validate node id). */
+    void *fbegin = NULL, *node = NULL;
+    if (!safe_memory_read_pointer((mach_vm_address_t)factory + 0x08, &fbegin) || !fbegin) return 1;
+    if (!safe_memory_read_pointer((mach_vm_address_t)fbegin + (uintptr_t)(nodeId - 1) * 8, &node) || !node) return 1;
+    uint32_t nodeChk = 0;
+    safe_memory_read_u32((mach_vm_address_t)node + 0x08, &nodeChk);
+    if (nodeChk != nodeId) {
+        LOG_OSIRIS_DEBUG("Osi DB: node id mismatch (%u != %u)", nodeChk, nodeId);
+        return 1;
+    }
+
+    uint32_t dbId = 0;
+    if (!safe_memory_read_u32((mach_vm_address_t)node + 0x18, &dbId) || dbId == 0) return 1;
+
+    /* node -> CReteDBase via databases vector (id-1 index; validate db id). */
+    void *dbegin = NULL, *db = NULL;
+    if (!safe_memory_read_pointer((mach_vm_address_t)dbmgr + 0x08, &dbegin) || !dbegin) return 1;
+    if (!safe_memory_read_pointer((mach_vm_address_t)dbegin + (uintptr_t)(dbId - 1) * 8, &db) || !db) return 1;
+    uint32_t dbChk = 0;
+    safe_memory_read_u32((mach_vm_address_t)db + 0x00, &dbChk);
+    if (dbChk != dbId) {
+        LOG_OSIRIS_DEBUG("Osi DB: database id mismatch (%u != %u)", dbChk, dbId);
+        return 1;
+    }
+
+    uint8_t colCount = 0;
+    safe_memory_read_u8((mach_vm_address_t)db + 0x40, &colCount);
+    if (colCount == 0 || colCount > 32) {
+        LOG_OSIRIS_DEBUG("Osi DB: implausible column count %u", colCount);
+        return 1;
+    }
+
+    /* Walk the fact list (std::list<CTuple> sentinel @ db+0x10). */
+    mach_vm_address_t sentinel = (mach_vm_address_t)db + 0x10;
+    void *cur = NULL;
+    if (!safe_memory_read_pointer((mach_vm_address_t)db + 0x18, &cur)) return 1;
+
+    int guard = 0;
+    while (cur && (mach_vm_address_t)cur != sentinel && rowCount < 100000 && guard < 500000) {
+        guard++;
+
+        void *values = NULL;   /* CTuple.values = *(node+0x10) */
+        safe_memory_read_pointer((mach_vm_address_t)cur + 0x10, &values);
+
+        int match = (values != NULL);
+        for (int i = 0; i < nfilter && match; i++) {
+            int slot = 2 + i;
+            if (lua_isnil(L, slot)) continue;      /* wildcard */
+            if ((uint32_t)i >= colCount) { match = 0; break; }
+            mach_vm_address_t tv = (mach_vm_address_t)values + (mach_vm_address_t)i * 0x10;
+            uint16_t colType = 0;
+            safe_memory_read(tv + 0x08, &colType, sizeof(colType));
+            if (lua_type(L, slot) == LUA_TNUMBER) {
+                int64_t want = (int64_t)lua_tointeger(L, slot), got;
+                if (colType == OSI_TYPE_INTEGER) { uint32_t v = 0; safe_memory_read_u32(tv, &v); got = (int32_t)v; }
+                else { uint64_t v = 0; safe_memory_read_u64(tv, &v); got = (int64_t)v; }
+                if (got != want) match = 0;
+            } else {
+                const char *want = lua_tostring(L, slot);
+                uint64_t handle = 0; char buf[256]; buf[0] = '\0';
+                safe_memory_read_u64(tv, &handle);
+                osi_resolve_string_handle(handle, buf, sizeof(buf));
+                if (!want || strcmp(buf, want) != 0) match = 0;
+            }
+        }
+
+        if (match) {
+            lua_newtable(L);                        /* row */
+            for (uint32_t i = 0; i < colCount; i++) {
+                osi_push_typed_value(L, (mach_vm_address_t)values + (mach_vm_address_t)i * 0x10);
+                lua_rawseti(L, -2, (int)i + 1);
+            }
+            rowCount++;
+            lua_rawseti(L, resultIdx, rowCount);
+        }
+
+        void *nxt = NULL;
+        if (!safe_memory_read_pointer((mach_vm_address_t)cur + 0x08, &nxt)) break;
+        cur = nxt;
+    }
+
+    LOG_OSIRIS_DEBUG("Osi DB (Facts): %d rows, %u cols", rowCount, colCount);
+    return 1;
+}
+
+/**
  * Generic Osi.DB_<name>:Get([filter...]) read-only accessor.
  *
  * Security: this function is QUERY-ONLY. It dispatches via g_divQuery
@@ -1259,6 +1440,13 @@ static int lua_osi_db_get(lua_State *L) {
         LOG_OSIRIS_WARN("Osi.DB_<?>:Get() called but DBName is missing");
         lua_newtable(L);
         return 1;
+    }
+
+    /* Real Osiris databases (registered by the name-index walk) have no dispatch
+     * id — read their Facts list directly (Windows-parity). */
+    void *dbDef = osi_db_lookup(db_name);
+    if (dbDef) {
+        return osi_db_read_facts(L, dbDef);
     }
 
     uint8_t arity = 0;
@@ -1390,15 +1578,14 @@ static int osi_value_to_lua(lua_State *L, OsiArgumentValue *val) {
             return 1;
         case OSI_TYPE_STRING:
         case OSI_TYPE_GUIDSTRING:
+        default:
+            // STRING/GUIDSTRING and all custom GUID subtypes (CHARACTERGUID,
+            // ITEMGUID, ... typeId > 5) carry a char* value from the engine.
             if (val->stringVal) {
                 lua_pushstring(L, val->stringVal);
             } else {
                 lua_pushstring(L, "");
             }
-            return 1;
-        default:
-            LOG_OSIRIS_DEBUG("Unknown type %d", val->typeId);
-            lua_pushnil(L);
             return 1;
     }
 }
@@ -1522,74 +1709,92 @@ static int osi_dynamic_call(lua_State *L) {
         numArgs = arity;
     }
 
-    // Allocate arguments based on clamped arg count.
-    // For queries, the full arity (in+out) is needed — this requires
-    // correct ParamCount from funcDef. See osi_func_enumerate() for offset.
+    // Build the Osiris argument chain. Prefer the game's authoritative param
+    // definitions (types + in/out directions) read from the OsirisInterface —
+    // the same structure OsirisQuery validates against. Fall back to guessing
+    // arity/types (legacy) if the defs are unavailable.
+    OsiParamDef pdefs[20];
+    int pcount = osi_read_param_defs(funcId, pdefs, 20);
+    int useDefs = (pcount >= 0);
+    int numOut = 0;
     int allocCount = numArgs;
-    if ((funcType == OSI_FUNC_QUERY || funcType == OSI_FUNC_SYSQUERY ||
-         funcType == OSI_FUNC_USERQUERY) && arity > numArgs) {
-        allocCount = arity;
-        LOG_OSIRIS_DEBUG("Osi.%s: Query allocated %d slots (luaArgs=%d, arity=%d)",
-                        funcName, allocCount, numArgs, arity);
-    }
-
     OsiArgumentDesc *args = NULL;
-    if (allocCount > 0) {
-        args = alloc_args(allocCount);
-        if (!args) {
-            return luaL_error(L, "Failed to allocate Osiris arguments");
+
+    if (useDefs) {
+        allocCount = pcount;
+        if (allocCount > 0) {
+            args = alloc_args(allocCount);
+            if (!args) return luaL_error(L, "Failed to allocate Osiris arguments");
+            int luaIdx = 1;  // next Lua input arg (stack index; inputs start at 1)
+            for (int i = 0; i < allocCount; i++) {
+                uint16_t decl = (uint16_t)pdefs[i].type;
+                if (pdefs[i].direction == 2) {  // OUTPUT: declared type, zeroed value
+                    args[i].value.stringVal = NULL;
+                    args[i].value.typeId = decl;
+                    numOut++;
+                    continue;
+                }
+                // INPUT: consume the next Lua arg, using the declared type.
+                int haveArg = (luaIdx <= numArgs);
+                int lt = haveArg ? lua_type(L, luaIdx) : LUA_TNIL;
+                if (decl == OSI_TYPE_INTEGER) {
+                    args[i].value.typeId = OSI_TYPE_INTEGER;
+                    args[i].value.int32Val = haveArg ? (int32_t)lua_tointeger(L, luaIdx) : 0;
+                } else if (decl == OSI_TYPE_INTEGER64) {
+                    args[i].value.typeId = OSI_TYPE_INTEGER64;
+                    args[i].value.int64Val = haveArg ? (int64_t)lua_tointeger(L, luaIdx) : 0;
+                } else if (decl == OSI_TYPE_REAL) {
+                    args[i].value.typeId = OSI_TYPE_REAL;
+                    args[i].value.floatVal = haveArg ? (float)lua_tonumber(L, luaIdx) : 0.0f;
+                } else {  // string / GUID family: pass Lua string with declared type
+                    const char *s = "";
+                    if (haveArg && (lt == LUA_TSTRING || lt == LUA_TNUMBER)) s = lua_tostring(L, luaIdx);
+                    args[i].value.typeId = decl;
+                    args[i].value.stringVal = (char *)s;
+                }
+                luaIdx++;
+            }
+            LOG_OSIRIS_DEBUG("Osi.%s: %d params (%d out) from signature, luaArgs=%d",
+                            funcName, pcount, numOut, numArgs);
         }
-
-        // Convert Lua arguments to Osiris arguments (input slots only)
-        for (int i = 0; i < numArgs; i++) {
-            int argIdx = i + 1;  // Lua indices start at 1
-            int luaType = lua_type(L, argIdx);
-
-            switch (luaType) {
-                case LUA_TSTRING: {
-                    const char *str = lua_tostring(L, argIdx);
-                    // Check if it looks like a GUID
-                    int isGuid = (str && strlen(str) >= 36 &&
-                                  strchr(str, '-') != NULL);
-                    set_arg_string(&args[i], str, isGuid);
-                    break;
-                }
-                case LUA_TNUMBER: {
-                    if (lua_isinteger(L, argIdx)) {
-                        set_arg_int(&args[i], (int32_t)lua_tointeger(L, argIdx));
-                    } else {
-                        set_arg_real(&args[i], (float)lua_tonumber(L, argIdx));
+    } else {
+        // Legacy fallback: guess arity/types.
+        if ((funcType == OSI_FUNC_QUERY || funcType == OSI_FUNC_SYSQUERY ||
+             funcType == OSI_FUNC_USERQUERY) && arity > numArgs) {
+            allocCount = arity;
+        }
+        if (allocCount > 0) {
+            args = alloc_args(allocCount);
+            if (!args) return luaL_error(L, "Failed to allocate Osiris arguments");
+            for (int i = 0; i < numArgs; i++) {
+                int argIdx = i + 1;
+                int luaType = lua_type(L, argIdx);
+                switch (luaType) {
+                    case LUA_TSTRING: {
+                        const char *str = lua_tostring(L, argIdx);
+                        int isGuid = (str && strlen(str) >= 36 && strchr(str, '-') != NULL);
+                        set_arg_string(&args[i], str, isGuid);
+                        break;
                     }
-                    break;
-                }
-                case LUA_TBOOLEAN: {
-                    set_arg_int(&args[i], lua_toboolean(L, argIdx) ? 1 : 0);
-                    break;
-                }
-                case LUA_TNIL: {
-                    // Nil treated as empty string
-                    set_arg_string(&args[i], "", 0);
-                    break;
-                }
-                default: {
-                    LOG_OSIRIS_DEBUG("Osi.%s: Warning: Unsupported arg type %d at position %d",
-                                funcName, luaType, argIdx);
-                    set_arg_string(&args[i], "", 0);
-                    break;
+                    case LUA_TNUMBER:
+                        if (lua_isinteger(L, argIdx)) set_arg_int(&args[i], (int32_t)lua_tointeger(L, argIdx));
+                        else set_arg_real(&args[i], (float)lua_tonumber(L, argIdx));
+                        break;
+                    case LUA_TBOOLEAN: set_arg_int(&args[i], lua_toboolean(L, argIdx) ? 1 : 0); break;
+                    default: set_arg_string(&args[i], "", 0); break;
                 }
             }
-        }
-        // Pre-initialize output slot TypeIds for queries.
-        // DivQuery calls COsiArgumentDesc::GetDataSrcPtr() which needs a valid typeId
-        // to return the correct union member pointer. Without this, typeId=0 (NONE) causes
-        // a C++ exception → std::terminate → SIGABRT.
-        // Windows BG3SE reads exact types from Signature->Params (Function.inl:376).
-        // Default to GUIDSTRING (type 5) which is the most common Osiris output type.
-        // TODO: Read actual param types from funcDef->Signature->Params linked list.
-        if (funcType == OSI_FUNC_QUERY || funcType == OSI_FUNC_SYSQUERY ||
-            funcType == OSI_FUNC_USERQUERY) {
-            for (int i = numArgs; i < allocCount; i++) {
-                args[i].value.typeId = OSI_TYPE_GUIDSTRING;
+            // Pre-initialize output slot TypeIds for queries: DivQuery calls
+            // COsiArgumentDesc::GetDataSrcPtr() which needs a valid typeId
+            // (typeId=0 raises a C++ exception -> SIGABRT). GUIDSTRING is the
+            // most common output type.
+            if (funcType == OSI_FUNC_QUERY || funcType == OSI_FUNC_SYSQUERY ||
+                funcType == OSI_FUNC_USERQUERY) {
+                for (int i = numArgs; i < allocCount; i++) {
+                    args[i].value.stringVal = NULL;
+                    args[i].value.typeId = OSI_TYPE_GUIDSTRING;
+                }
+                numOut = allocCount - numArgs;
             }
         }
     }
@@ -1636,21 +1841,39 @@ static int osi_dynamic_call(lua_State *L) {
                 LOG_OSIRIS_DEBUG("Osi.%s: Query returned %d (via %s, handle=0x%08x)", funcName, result,
                                 g_divQuery ? "DivQuery" : "InternalQuery", dispatchHandle);
 
-                if (result && allocCount > numArgs) {
-                    // Return output args (slots after the input args)
+                if (result && numOut > 0) {
+                    // Return output-param values. With signature defs, outputs are
+                    // the direction==2 params (anywhere in the list); in the legacy
+                    // path they are the slots after the inputs.
                     int returnCount = 0;
-                    for (int i = numArgs; i < allocCount; i++) {
-                        osi_value_to_lua(L, &args[i].value);
-                        returnCount++;
+                    if (useDefs) {
+                        for (int i = 0; i < allocCount; i++) {
+                            if (pdefs[i].direction == 2) {
+                                osi_value_to_lua(L, &args[i].value);
+                                returnCount++;
+                            }
+                        }
+                    } else {
+                        for (int i = numArgs; i < allocCount; i++) {
+                            osi_value_to_lua(L, &args[i].value);
+                            returnCount++;
+                        }
                     }
-                    LOG_OSIRIS_DEBUG("Osi.%s: Returning %d output values from query (slots %d..%d)",
-                                    funcName, returnCount, numArgs, allocCount - 1);
+                    LOG_OSIRIS_DEBUG("Osi.%s: returning %d output value(s)", funcName, returnCount);
                     return returnCount;
-                } else if (result) {
-                    lua_pushboolean(L, 1);
+                } else if (numOut > 0) {
+                    // Query has output params but DID NOT MATCH (result==0): it
+                    // produced no tuple, so there is no value. Return nil — NOT 0.
+                    // e.g. CharacterGetOwner(char-with-no-owner) must be nil so mod
+                    // logic like `owner and ...` short-circuits (0/"" are truthy in
+                    // Lua and would wrongly proceed).
+                    lua_pushnil(L);
                     return 1;
                 } else {
-                    lua_pushnil(L);
+                    // Pure test query (no output params): the DivQuery return IS the
+                    // boolean result. Osiris returns these as INTEGER 0/1 — mods
+                    // compare `== 0` / `== 1` (e.g. `if Osi.HasSpell(c,s) == 0`).
+                    lua_pushinteger(L, result ? 1 : 0);
                     return 1;
                 }
             }
@@ -1791,6 +2014,56 @@ static int osi_index_handler(lua_State *L) {
 /**
  * Register Osi namespace with dynamic metatable
  */
+/**
+ * _G __index fallback: expose Osiris functions as bare globals.
+ *
+ * Windows BG3SE runs GenerateOsiHelpers() at story load, injecting
+ *   IsTagged = Osi.IsTagged   (and one line per Osiris symbol)
+ * into the global table, so mods can call Osiris functions as bare globals
+ * (e.g. `if IsTagged(char, tag) == 1`). Many mods depend on this — without it
+ * the bare call hits a nil global and the whole Osiris listener aborts (seen
+ * live: Expansion's Equipped/Unequipped/LevelGameplayStarted handlers).
+ *
+ * Rather than a one-shot dump we resolve lazily via _G's metatable, so symbols
+ * discovered after bootstrap (databases, late-registered functions) are covered
+ * too. Only names backed by a real Osiris function resolve; genuine unknown
+ * globals still return nil so mod `if X == nil` feature checks keep working.
+ * A pre-existing __index (captured as upvalue 1) is honored as a fallback.
+ */
+static int lua_global_osi_fallback(lua_State *L) {
+    // stack: [1]=_G, [2]=key
+    const char *key = lua_tostring(L, 2);
+    if (key && osi_func_lookup_id(key) != INVALID_FUNCTION_ID) {
+        lua_getglobal(L, "Osi");            // [_G, key, Osi]
+        if (lua_istable(L, -1)) {
+            lua_pushvalue(L, 2);            // key
+            lua_gettable(L, -2);            // Osi[key] (osi_index_handler resolves + caches)
+            if (!lua_isnil(L, -1)) {
+                lua_pushvalue(L, 2);        // key
+                lua_pushvalue(L, -2);       // Osi[key]
+                lua_rawset(L, 1);           // _G[key] = Osi[key] (skip metamethod next time)
+                return 1;                   // return Osi[key]
+            }
+        }
+    }
+    // Honor any pre-existing __index (upvalue 1).
+    int prev = lua_upvalueindex(1);
+    if (lua_istable(L, prev)) {
+        lua_pushvalue(L, prev);
+        lua_pushvalue(L, 2);
+        lua_gettable(L, -2);
+        return 1;
+    } else if (lua_isfunction(L, prev)) {
+        lua_pushvalue(L, prev);
+        lua_pushvalue(L, 1);
+        lua_pushvalue(L, 2);
+        lua_call(L, 2, 1);
+        return 1;
+    }
+    lua_pushnil(L);
+    return 1;
+}
+
 static void register_osi_namespace(lua_State *L) {
     // Create Osi table
     lua_newtable(L);
@@ -1798,8 +2071,14 @@ static void register_osi_namespace(lua_State *L) {
     // Pre-register known functions that have special implementations
     // These override the dynamic lookup for better behavior
 
-    lua_pushcfunction(L, lua_osi_istagged);
-    lua_setfield(L, -2, "IsTagged");
+    // NOTE: Osi.IsTagged is deliberately NOT bound to a dedicated C function.
+    // The hand-rolled helper hardcoded the tag argument as GUIDSTRING, but the
+    // Osiris IsTagged query declares that param as the TAG subtype; the strict
+    // OsirisQuery type check then rejected the call and every tag read false,
+    // breaking all tag-driven mod logic (e.g. the Demon Hunter class). Leaving
+    // IsTagged unbound routes it through osi_index_handler -> osi_dynamic_call,
+    // which reads the game's authoritative param defs (types + in/out dirs) and
+    // types the argument correctly. Verified live: Osi.IsTagged(host, DH_TAG) -> 1.
 
     lua_pushcfunction(L, lua_osi_getdistanceto);
     lua_setfield(L, -2, "GetDistanceTo");
@@ -1832,6 +2111,21 @@ static void register_osi_namespace(lua_State *L) {
     // Also register GetHostCharacter as a global function
     lua_pushcfunction(L, lua_gethostcharacter);
     lua_setglobal(L, "GetHostCharacter");
+
+    // Expose all Osiris functions as bare globals (Windows GenerateOsiHelpers
+    // parity) by installing a resolving __index on _G's metatable. Preserves any
+    // existing __index as an upvalue fallback.
+    {
+        lua_pushglobaltable(L);                              // [_G]
+        int hadMeta = lua_getmetatable(L, -1);               // [_G, mt?]
+        if (!hadMeta) lua_newtable(L);                       // [_G, mt]
+        lua_getfield(L, -1, "__index");                      // [_G, mt, prev__index]
+        lua_pushcclosure(L, lua_global_osi_fallback, 1);     // [_G, mt, closure]
+        lua_setfield(L, -2, "__index");                      // mt.__index = closure ; [_G, mt]
+        if (!hadMeta) lua_setmetatable(L, -2);               // setmetatable(_G, mt) ; [_G]
+        else lua_pop(L, 1);                                  // [_G]
+        lua_pop(L, 1);                                       // []
+    }
 
     LOG_OSIRIS_INFO("Osi namespace registered with dynamic metatable");
 }
@@ -2656,6 +2950,67 @@ static void set_arg_real(OsiArgumentDesc *arg, float value) {
     arg->value.floatVal = value;
 }
 
+// ---------------------------------------------------------------------------
+// Authoritative Osiris param definitions (types + in/out directions)
+// ---------------------------------------------------------------------------
+// The port previously guessed arity from the COsiFunctionData signature (which
+// reads 0 for many DIV/engine functions) and defaulted every output slot to
+// GUIDSTRING. osi::OsirisInterface::OsirisQuery (0x105c093b0 on 7209685)
+// strictly type-checks OUTPUT args against each param's declared type, so a
+// GUIDSTRING slot for an INTEGER output makes the whole query return 0. Read
+// the game's real param defs from the same structure OsirisQuery uses:
+//   g_instance = *(binary_base + osiris_interface_ptr)   (offset table, per version)
+//   idx  = (handle >> 3) & 0x1ffffff
+//   fn   = (*( *(g_instance+8) + 0x20 ))[idx]            (bound = *( *(g_instance+8)+0x2c ))
+//   paramCount = *(fn+0x18);  params = *(fn+0x10)
+//   each param 0x10 bytes: type(u32) @ +0x08, direction(u32: 1=in,2=out) @ +0x0c
+// The slot has no nm symbol — its per-version value is verified by disassembling
+// OsirisQuery's ADRP+LDR pair (see offset_table.c / OSIRIS_DATABASES.md).
+
+// Fills defs[] for the function identified by `handle`. Returns param count
+// (>=0) on success, or -1 if unavailable (caller falls back to guessing). All
+// reads go through safe_memory so a wrong/unmapped address fails gracefully.
+static int osi_read_param_defs(uint32_t handle, OsiParamDef *defs, int maxDefs) {
+    const VersionOffsets *off = offset_table_get();
+    if (!off || !off->osiris_interface_ptr) return -1;   // fail closed: unknown version
+    void *slot = offset_table_resolve(off->osiris_interface_ptr);
+    if (!slot) return -1;
+    void *instance = NULL;
+    if (!safe_memory_read_pointer((mach_vm_address_t)slot, &instance) || !instance)
+        return -1;
+    void *sub = NULL;
+    if (!safe_memory_read_pointer((mach_vm_address_t)instance + 0x08, &sub) || !sub)
+        return -1;
+    uint32_t bound = 0;
+    if (!safe_memory_read_u32((mach_vm_address_t)sub + 0x2c, &bound))
+        return -1;
+    uint32_t idx = (handle >> 3) & 0x1ffffff;
+    if (idx >= bound || bound > 1000000)  // sanity on the array bound
+        return -1;
+    void *funcArray = NULL;
+    if (!safe_memory_read_pointer((mach_vm_address_t)sub + 0x20, &funcArray) || !funcArray)
+        return -1;
+    void *fn = NULL;
+    if (!safe_memory_read_pointer((mach_vm_address_t)funcArray + (mach_vm_address_t)idx * 8, &fn) || !fn)
+        return -1;
+    uint32_t pcount = 0;
+    if (!safe_memory_read_u32((mach_vm_address_t)fn + 0x18, &pcount) || pcount > 20)
+        return -1;
+    void *params = NULL;
+    if (pcount > 0 &&
+        (!safe_memory_read_pointer((mach_vm_address_t)fn + 0x10, &params) || !params))
+        return -1;
+    for (uint32_t i = 0; i < pcount && (int)i < maxDefs; i++) {
+        mach_vm_address_t p = (mach_vm_address_t)params + (mach_vm_address_t)i * 0x10;
+        uint32_t type = 0, dir = 0;
+        safe_memory_read_u32(p + 0x08, &type);
+        safe_memory_read_u32(p + 0x0c, &dir);
+        defs[i].type = type;
+        defs[i].direction = (uint8_t)dir;
+    }
+    return (int)pcount;
+}
+
 /**
  * Execute an Osiris query by function ID
  * Returns 1 on success, 0 on failure
@@ -2758,13 +3113,24 @@ static int osi_is_tagged(const char *character, const char *tag) {
         return -1;  // Unknown
     }
 
-    OsiArgumentDesc *args = alloc_args(2);
+    // IsTagged is a 3-arity query: (GUIDSTRING _Object, GUIDSTRING _Tag,
+    // [out]INTEGER _IsTagged). The boolean result is delivered through the OUT
+    // param, NOT the query's success flag. Allocating only 2 args (missing the
+    // out slot) makes the game's OsirisQuery strict param check reject the call
+    // and return 0, so every tag read false — breaking all tag-driven mod logic.
+    // Mirrors osi_get_distance_to, which correctly handles GetDistanceTo's out param.
+    OsiArgumentDesc *args = alloc_args(3);
     if (!args) return -1;
 
-    set_arg_string(&args[0], character, 1);  // GUID
-    set_arg_string(&args[1], tag, 1);        // GUID
+    set_arg_string(&args[0], character, 1);   // GUID (in)
+    set_arg_string(&args[1], tag, 1);         // GUID/TAG (in)
+    args[2].value.typeId = OSI_TYPE_INTEGER;  // out param (isTagged 0/1)
+    args[2].value.int32Val = 0;
 
-    return osiris_query_by_id(funcId, args);
+    if (osiris_query_by_id(funcId, args)) {
+        return args[2].value.int32Val;
+    }
+    return 0;
 }
 
 /**
@@ -3123,6 +3489,32 @@ after_tick:
         }
     }
 
+    // Story-load database discovery: Osiris databases (DB_Players,
+    // DB_PartyMembers, DB_Avatars, ...) live ONLY in the name index, not the
+    // numeric id-index the early enumeration probes — so Osi.DB_*:Get() can
+    // never resolve them and returns empty (breaking mods like Sit This One Out
+    // whose grant loops iterate DB_PartyMembers). SavegameLoaded and
+    // LevelGameplayStarted fire after story load, so walk the name index here
+    // BEFORE dispatching to Lua callbacks. One-shot flag: run once per session
+    // (not on every level transition); the walk is idempotent and read-only.
+    static int g_dbNamesEnumerated = 0;
+    if (!g_dbNamesEnumerated && funcName &&
+        (strcmp(funcName, "SavegameLoaded") == 0 ||
+         strcmp(funcName, "LevelGameplayStarted") == 0)) {
+        g_dbNamesEnumerated = 1;
+        LOG_OSIRIS_INFO("Story loaded (%s) — walking Osiris name index to "
+                        "discover databases", funcName);
+        osi_func_enumerate_by_name();
+    }
+
+    // Osiris events are server-side. After bootstrap, the context is left at
+    // CLIENT (Phase 2 client-bootstrap load never resets it), so mod event
+    // handlers — and the Osi.* queries they make — would run mislabelled as
+    // client and hit client-side Osiris state (queries return 0, e.g. SitOut's
+    // HasActiveStatus). Force SERVER context around event dispatch and restore.
+    LuaContext prevCtx = lua_context_get();
+    lua_context_set(LUA_CONTEXT_SERVER);
+
     // Dispatch to "before" callbacks if we know the function name
     if (funcName) {
         dispatch_event_to_lua(funcName, arity, args, "before");
@@ -3137,6 +3529,8 @@ after_tick:
     if (funcName) {
         dispatch_event_to_lua(funcName, arity, args, "after");
     }
+
+    lua_context_set(prevCtx);
 }
 
 /**

--- a/src/injector/main.c
+++ b/src/injector/main.c
@@ -407,36 +407,57 @@ static lua_State *L = NULL;
 static dispatch_source_t s_console_poll_timer = NULL;
 
 // Module loading state
-#define MAX_LOADED_MODULES 256
-static char loaded_modules[MAX_LOADED_MODULES][MAX_PATH_LEN];
-static int loaded_module_count = 0;
 static char mods_base_path[MAX_PATH_LEN] = "";
 
 // ============================================================================
 // Module Loading Helpers
 // ============================================================================
 
-/**
- * Check if a module has already been loaded
- */
-static int is_module_loaded(const char *full_path) {
-    for (int i = 0; i < loaded_module_count; i++) {
-        if (strcmp(loaded_modules[i], full_path) == 0) {
-            return 1;
-        }
+// Ext.Require caches each module's RETURN VALUE (like Lua's require /
+// package.loaded) so repeated requires of the same file return the same value.
+// A registry table keyed by full module path holds the results.
+#define BG3SE_MODULE_CACHE_KEY "BG3SE_ModuleCache"
+
+// Push the module cache table onto the stack (creating it on first use).
+static void push_module_cache(lua_State *L) {
+    lua_getfield(L, LUA_REGISTRYINDEX, BG3SE_MODULE_CACHE_KEY);
+    if (lua_isnil(L, -1)) {
+        lua_pop(L, 1);
+        lua_newtable(L);
+        lua_pushvalue(L, -1);
+        lua_setfield(L, LUA_REGISTRYINDEX, BG3SE_MODULE_CACHE_KEY);
     }
-    return 0;
 }
 
-/**
- * Mark a module as loaded
- */
-static void mark_module_loaded(const char *full_path) {
-    if (loaded_module_count < MAX_LOADED_MODULES) {
-        strncpy(loaded_modules[loaded_module_count], full_path, MAX_PATH_LEN - 1);
-        loaded_modules[loaded_module_count][MAX_PATH_LEN - 1] = '\0';
-        loaded_module_count++;
+// If `key` is cached, leave its value on top of the stack and return 1;
+// otherwise leave the stack unchanged and return 0.
+static int require_cache_hit(lua_State *L, const char *key) {
+    push_module_cache(L);              // [.., cache]
+    lua_getfield(L, -1, key);          // [.., cache, val]
+    if (lua_isnil(L, -1)) {
+        lua_pop(L, 2);                 // [..]
+        return 0;
     }
+    lua_remove(L, -2);                 // [.., val]
+    return 1;
+}
+
+// After a successful load (module return values sit above the single `path`
+// arg at stack index 1), normalize to one value at index 2 — using boolean
+// true when the module returned nothing/nil, matching Lua require — cache it
+// under `key`, and leave exactly that value on top for return. Returns 1.
+static int require_finish(lua_State *L, const char *key) {
+    if (lua_gettop(L) < 2 || lua_isnil(L, 2)) {
+        lua_settop(L, 1);
+        lua_pushboolean(L, 1);         // [path, true]
+    } else {
+        lua_settop(L, 2);              // [path, val]
+    }
+    push_module_cache(L);              // [path, val, cache]
+    lua_pushvalue(L, 2);               // [path, val, cache, val]
+    lua_setfield(L, -2, key);          // cache[key] = val ; [path, val, cache]
+    lua_pop(L, 1);                     // [path, val]
+    return 1;
 }
 
 /**
@@ -575,9 +596,14 @@ static char *get_mod_table_name(const char *mod_name) {
 /**
  * Set up Mods.<ModTable> namespace in Lua
  * Creates the global 'Mods' table if it doesn't exist
- * Creates the Mods.<mod_table> subtable
+ * Creates the Mods.<mod_table> subtable, pre-seeded with ModuleUUID.
+ *
+ * The ModuleUUID field is required: MCM installs a __newindex metamethod on the
+ * global Mods table and, when a mod's table is inserted, reads value.ModuleUUID
+ * to inject its per-mod API (Mods[x].MCM etc.). It must be present *before* the
+ * table is assigned into Mods, so set it on the new table first.
  */
-static void setup_mod_namespace(lua_State *L, const char *mod_table) {
+static void setup_mod_namespace(lua_State *L, const char *mod_table, const char *uuid) {
     // Get or create global 'Mods' table
     lua_getglobal(L, "Mods");
     if (lua_isnil(L, -1)) {
@@ -588,13 +614,95 @@ static void setup_mod_namespace(lua_State *L, const char *mod_table) {
         LOG_LUA_INFO("Created global 'Mods' table");
     }
 
-    // Now Mods table is on stack
-    // Create Mods.<mod_table> = {}
-    lua_newtable(L);
-    lua_setfield(L, -2, mod_table);
-    lua_pop(L, 1);  // Pop Mods table
+    // Now Mods table is on stack. Build Mods.<mod_table> = { ModuleUUID = uuid }
+    lua_newtable(L);                       // [Mods, modtbl]
+    if (uuid && uuid[0]) {
+        lua_pushstring(L, uuid);           // [Mods, modtbl, uuid]
+        lua_setfield(L, -2, "ModuleUUID"); // modtbl.ModuleUUID = uuid ; [Mods, modtbl]
+    }
+    lua_setfield(L, -2, mod_table);        // Mods[mod_table] = modtbl (MCM sees ModuleUUID)
+    lua_pop(L, 1);                         // Pop Mods table
 
     LOG_LUA_INFO("Created namespace Mods.%s", mod_table);
+}
+
+// ============================================================================
+// Per-mod Lua environment (_ENV)
+// ----------------------------------------------------------------------------
+// Windows BG3SE runs each mod's Lua chunks with _ENV = Mods.<ModTable>: reads of
+// undefined globals fall back to the real _G (Ext, Osi, string, ...), while
+// writes to new globals stay mod-local (they land in Mods.<ModTable>). Mods like
+// MCM depend on this: they publish their API via `modTable.MCM = ...` and then
+// reference it as a bare global `MCM` from closures. Without a per-mod _ENV those
+// bare references resolve against the shared _G and are nil, which aborts MCM's
+// client init (InitService.lua) and leaves an empty config window.
+//
+// g_mod_env_ref holds a registry ref to the current mod's environment table
+// (== Mods.<ModTable>, given an { __index = _G } metatable). It is installed onto
+// each freshly loaded mod chunk via mod_env_apply() before the chunk runs.
+static int g_mod_env_ref = LUA_NOREF;
+
+// Make Mods.<mod_table> the active per-mod _ENV for subsequently loaded chunks.
+// Ensures the table exists, carries an { __index = _G } metatable, and has its
+// ModuleUUID seeded mod-locally. Pass mod_table == NULL to clear.
+static void mod_env_set(lua_State *L, const char *mod_table, const char *uuid) {
+    if (g_mod_env_ref != LUA_NOREF) {
+        luaL_unref(L, LUA_REGISTRYINDEX, g_mod_env_ref);
+        g_mod_env_ref = LUA_NOREF;
+    }
+    if (!mod_table || !mod_table[0]) return;
+
+    lua_getglobal(L, "Mods");                 // [Mods]
+    if (!lua_istable(L, -1)) { lua_pop(L, 1); return; }
+
+    lua_getfield(L, -1, mod_table);           // [Mods, E]
+    if (!lua_istable(L, -1)) {
+        lua_pop(L, 1);                        // [Mods]
+        lua_newtable(L);                      // [Mods, E]
+        lua_pushvalue(L, -1);                 // [Mods, E, E]
+        lua_setfield(L, -3, mod_table);       // Mods[mod_table] = E ; [Mods, E]
+    }
+
+    // Seed ModuleUUID mod-locally so runtime reads resolve to the right mod.
+    if (uuid && uuid[0]) {
+        lua_pushstring(L, uuid);
+        lua_setfield(L, -2, "ModuleUUID");
+    }
+
+    // Ensure { __index = _G } metatable (reads fall back to real globals).
+    if (lua_getmetatable(L, -1)) {
+        lua_pop(L, 1);                        // already has one; leave it
+    } else {
+        lua_newtable(L);                      // [Mods, E, mt]
+        lua_pushglobaltable(L);               // [Mods, E, mt, _G]
+        lua_setfield(L, -2, "__index");       // mt.__index = _G
+        lua_setmetatable(L, -2);              // setmetatable(E, mt) ; [Mods, E]
+    }
+
+    // Make _G inside this mod refer to the mod's own environment (Windows parity).
+    // Mods commonly define bare globals (Foo = {}) — which land in this env table E —
+    // and then read them back via `_G["Foo"]`. Without this, `_G` resolves to the
+    // REAL global table (where the mod's writes never went), so `_G[name]` returns
+    // nil. That silently breaks library mods like CommunityLibrary (its Import() does
+    // `_G[val]`), which cascades into every mod that depends on them (e.g.
+    // SubclassCompatibilityFramework -> CLUtils nil -> modded class level-up broken).
+    // Verified live: with E._G = E, CommunityLibrary.Import() returns its tables.
+    lua_pushvalue(L, -1);                     // [Mods, E, E]
+    lua_setfield(L, -2, "_G");                // E._G = E ; [Mods, E]
+
+    lua_pushvalue(L, -1);                     // [Mods, E, E]
+    g_mod_env_ref = luaL_ref(L, LUA_REGISTRYINDEX);  // pops E ; [Mods, E]
+    lua_pop(L, 2);                            // [] pop E, Mods
+}
+
+// Install the active per-mod _ENV (if any) on the chunk currently on top of the
+// stack. Lua 5.4: _ENV is upvalue #1 of a main chunk.
+static void mod_env_apply(lua_State *L) {
+    if (g_mod_env_ref == LUA_NOREF) return;
+    lua_rawgeti(L, LUA_REGISTRYINDEX, g_mod_env_ref);  // [func, E]
+    if (lua_setupvalue(L, -2, 1) == NULL) {
+        lua_pop(L, 1);  // chunk had no _ENV upvalue; discard E
+    }
 }
 
 /**
@@ -631,6 +739,9 @@ static int try_load_lua_file(lua_State *L, const char *full_path) {
         return 0;
     }
 
+    // Install the per-mod _ENV (Mods.<ModTable>) before running the chunk.
+    mod_env_apply(L);
+
     // Execute the loaded chunk
     if (lua_pcall(L, 0, LUA_MULTRET, 0) != LUA_OK) {
         LOG_LUA_INFO("Error executing %s: %s", full_path, lua_tostring(L, -1));
@@ -642,40 +753,27 @@ static int try_load_lua_file(lua_State *L, const char *full_path) {
 }
 
 /**
- * Ext.Require(path) - Load and execute a Lua module
- * Paths are relative to the current mod's ScriptExtender/Lua/ folder
- * Modules are cached - subsequent calls return cached results
- * Supports loading from both filesystem (extracted mods) and PAK files
+ * Core module resolver. `path` is a mod-relative path ending in .lua (e.g.
+ * "Lib/reactivex/util.lua"). Loads/executes from the current mod's filesystem
+ * base or PAK, caches by path, and leaves the module's value (or nil) on the
+ * stack. Returns 1.
  */
-static int lua_ext_require(lua_State *L) {
-    const char *path = luaL_checkstring(L, 1);
-    LOG_LUA_INFO("Ext.Require('%s')", path);
-
+static int require_resolve(lua_State *L, const char *path) {
     const char *lua_base = mod_get_current_lua_base();
     const char *pak_path = mod_get_current_pak_path();
     const char *mod_name = mod_get_current_name();
 
     // Try filesystem first (for extracted mods)
     if (lua_base && strlen(lua_base) > 0) {
-        // Build full path using the base path from where bootstrap was loaded
         char full_path[MAX_PATH_LEN];
         snprintf(full_path, sizeof(full_path), "%s/%s", lua_base, path);
 
-        // Check if already loaded
-        if (is_module_loaded(full_path)) {
-            LOG_LUA_INFO("Module already loaded: %s", path);
-            lua_pushnil(L);
+        if (require_cache_hit(L, full_path)) {
             return 1;
         }
-
-        // Try to load from the tracked base path
         if (try_load_lua_file(L, full_path)) {
-            mark_module_loaded(full_path);
             LOG_LUA_INFO("Loaded module from: %s", full_path);
-            if (lua_gettop(L) == 0) {
-                lua_pushnil(L);
-            }
-            return 1;
+            return require_finish(L, full_path);
         }
     }
 
@@ -685,38 +783,63 @@ static int lua_ext_require(lua_State *L) {
         snprintf(pak_lua_path, sizeof(pak_lua_path),
                  "Mods/%s/ScriptExtender/Lua/%s", mod_name, path);
 
-        // Check if already loaded (use PAK path as key)
         char cache_key[MAX_PATH_LEN];
         snprintf(cache_key, sizeof(cache_key), "pak:%s:%s", pak_path, pak_lua_path);
 
-        if (is_module_loaded(cache_key)) {
-            LOG_LUA_INFO("Module already loaded from PAK: %s", path);
-            lua_pushnil(L);
+        if (require_cache_hit(L, cache_key)) {
             return 1;
         }
-
         if (mod_load_lua_from_pak(L, pak_path, pak_lua_path)) {
-            mark_module_loaded(cache_key);
             LOG_LUA_INFO("Loaded module from PAK: %s", pak_lua_path);
-            if (lua_gettop(L) == 0) {
-                lua_pushnil(L);
-            }
-            return 1;
+            return require_finish(L, cache_key);
         }
     }
 
-    // Module not found
     LOG_LUA_WARN(" Module not found: %s", path);
-    if (lua_base && strlen(lua_base) > 0) {
-        LOG_LUA_INFO("  Tried filesystem: %s/%s", lua_base, path);
-    }
-    if (pak_path && strlen(pak_path) > 0) {
-        LOG_LUA_INFO("  Tried PAK: %s (Mods/%s/ScriptExtender/Lua/%s)",
-                    pak_path, mod_name, path);
-    }
-
     lua_pushnil(L);
     return 1;
+}
+
+/**
+ * Ext.Require(path) - Load and execute a Lua module.
+ * Paths are relative to the current mod's ScriptExtender/Lua/ folder and
+ * already include the .lua suffix. Results are cached per module path.
+ */
+static int lua_ext_require(lua_State *L) {
+    const char *path = luaL_checkstring(L, 1);
+    LOG_LUA_INFO("Ext.Require('%s')", path);
+    return require_resolve(L, path);
+}
+
+/**
+ * Global require(name) - many SE mods (MCM, CommunityLibrary) load modules with
+ * bare require() rather than Ext.Require. Accepts Lua module names ("a.b.c") or
+ * slash paths ("a/b/c"), with or without a .lua suffix, resolved like
+ * Ext.Require against the current mod.
+ */
+static int lua_require(lua_State *L) {
+    const char *name = luaL_checkstring(L, 1);
+    char rel[MAX_PATH_LEN];
+    size_t n = strlen(name);
+    int has_lua = (n >= 4 && strcmp(name + n - 4, ".lua") == 0);
+
+    if (has_lua) {
+        snprintf(rel, sizeof(rel), "%s", name);
+    } else if (strchr(name, '/') != NULL) {
+        // Already a slash path (MCM style): just add the extension.
+        snprintf(rel, sizeof(rel), "%s.lua", name);
+    } else {
+        // Lua module name: convert dot separators to slashes, then add .lua.
+        snprintf(rel, sizeof(rel), "%s", name);
+        for (char *p = rel; *p; p++) {
+            if (*p == '.') *p = '/';
+        }
+        size_t rl = strlen(rel);
+        snprintf(rel + rl, sizeof(rel) - rl, ".lua");
+    }
+
+    LOG_LUA_INFO("require('%s') -> %s", name, rel);
+    return require_resolve(L, rel);
 }
 
 // ============================================================================
@@ -750,9 +873,11 @@ static int lua_ext_register_net_listener(lua_State *L) {
 // ============================================================================
 
 static int lua_ext_utils_get_game_state(lua_State *L) {
-    int state = events_get_current_game_state();
-    const char *name = game_state_get_name((ServerGameState)state);
-    lua_pushstring(L, name);
+    // Return the Ext.Enums.ClientGameState EnumValue userdata (matching
+    // GameStateChanged's ToState) so mods can compare GetGameState() against
+    // Ext.Enums.ClientGameState.X with ==. MCM's IsMainMenu / open-on-start
+    // checks rely on this; a bare string never equals the EnumValue.
+    events_push_client_gamestate(L, events_get_current_game_state());
     return 1;
 }
 
@@ -939,6 +1064,18 @@ static void register_ext_api(lua_State *L) {
         "    end,\n"
         "  }\n"
         "  Ext.ModEvents = setmetatable({}, mt)\n"
+        "end\n"
+    );
+
+    // Ext.RegisterModEvent(mod, event) — Windows BG3SE API used by MCM and others
+    // to declare a cross-mod event before Subscribe/Throw. The port's ModEvents
+    // metatable creates events lazily on access, so registration just needs to
+    // touch the entry (and must exist as a function so callers don't hit nil).
+    luaL_dostring(L,
+        "Ext.RegisterModEvent = function(mod, event)\n"
+        "  if mod == nil or event == nil then return end\n"
+        "  local bucket = Ext.ModEvents[mod]\n"
+        "  if bucket then local _ = bucket[event] end\n"
         "end\n"
     );
 
@@ -2187,7 +2324,13 @@ static void register_global_functions(lua_State *L) {
     lua_pushcfunction(L, lua_global_dump);
     lua_setglobal(L, "_D");
 
-    LOG_LUA_INFO("Global debug functions registered (_P, _D)");
+    // Override the stock Lua require with a mod-aware loader so mods that use
+    // bare require("Some/Module") (MCM, CommunityLibrary) resolve against the
+    // current mod's Script Extender Lua folder.
+    lua_pushcfunction(L, lua_require);
+    lua_setglobal(L, "require");
+
+    LOG_LUA_INFO("Global functions registered (_P, _D, require)");
 }
 
 /**
@@ -2306,6 +2449,9 @@ static void load_mod_scripts(lua_State *L) {
 
     LOG_LUA_INFO("Loading %d detected SE mod(s)...", se_count);
 
+    // Route mod chunks loaded from PAK through the per-mod _ENV installer too.
+    mod_loader_set_chunk_env_hook(mod_env_apply);
+
     // Phase 1: Load all server bootstraps (in SERVER context)
     LOG_LUA_INFO("=== Loading Server Bootstraps ===");
     lua_context_set(LUA_CONTEXT_SERVER);
@@ -2315,14 +2461,23 @@ static void load_mod_scripts(lua_State *L) {
         // directory name, which can differ from the modsettings display name
         const char *mod_dir = mod_get_se_dir(i);
         if (!mod_dir || !mod_dir[0]) mod_dir = mod_get_se_name(i);
+        const char *mod_uuid = mod_get_se_uuid(i);
 
         // Get ModTable name from Config.json (or fallback to mod_dir)
         char *mod_table = get_mod_table_name(mod_dir);
         if (mod_table) {
-            // Set up Mods.<ModTable> namespace before loading scripts
-            setup_mod_namespace(L, mod_table);
+            // Set up Mods.<ModTable> namespace (seeded with ModuleUUID) before scripts
+            setup_mod_namespace(L, mod_table, mod_uuid);
+            // Make Mods.<ModTable> the active _ENV for this mod's chunks.
+            mod_env_set(L, mod_table, mod_uuid);
             free(mod_table);
         }
+
+        // Set the ModuleUUID global to this mod's UUID before running its
+        // bootstrap. Mods read ModuleUUID at bootstrap time (RegisterModVariable,
+        // Ext.Mod.GetMod(ModuleUUID), etc.); a nil value breaks those calls.
+        lua_pushstring(L, (mod_uuid && mod_uuid[0]) ? mod_uuid : "");
+        lua_setglobal(L, "ModuleUUID");
 
         // Load server bootstrap in SERVER context
         if (load_mod_bootstrap(L, mod_dir, "Server") > 0) {
@@ -2338,6 +2493,19 @@ static void load_mod_scripts(lua_State *L) {
     for (int i = 0; i < se_count; i++) {
         const char *mod_dir = mod_get_se_dir(i);
         if (!mod_dir || !mod_dir[0]) mod_dir = mod_get_se_name(i);
+        const char *mod_uuid = mod_get_se_uuid(i);
+
+        // Re-activate this mod's per-mod _ENV for the client phase (the server
+        // phase left the ref pointing at the last-loaded mod).
+        char *mod_table = get_mod_table_name(mod_dir);
+        if (mod_table) {
+            mod_env_set(L, mod_table, mod_uuid);
+            free(mod_table);
+        }
+
+        // Set ModuleUUID for this mod before its client bootstrap runs.
+        lua_pushstring(L, (mod_uuid && mod_uuid[0]) ? mod_uuid : "");
+        lua_setglobal(L, "ModuleUUID");
 
         // Load client bootstrap in CLIENT context
         if (load_mod_bootstrap(L, mod_dir, "Client") > 0) {
@@ -2549,7 +2717,12 @@ static void init_lua(void) {
         if (L && lua_gate_trylock()) {
             poll_misses = 0;
             if (L) {
+                // Run console commands in SERVER context so Osiris queries/DB
+                // reads match server-side game state (matches how mods run).
+                LuaContext prev = lua_context_get();
+                lua_context_set(LUA_CONTEXT_SERVER);
                 console_poll(L);
+                lua_context_set(prev);
             }
             lua_gate_unlock();
         } else if (L) {

--- a/src/injector/main.c
+++ b/src/injector/main.c
@@ -671,7 +671,18 @@ static void mod_env_set(lua_State *L, const char *mod_table, const char *uuid) {
 
     // Ensure { __index = _G } metatable (reads fall back to real globals).
     if (lua_getmetatable(L, -1)) {
-        lua_pop(L, 1);                        // already has one; leave it
+        // Already has one (mod-authored or from an earlier phase): respect it,
+        // but if it lacks __index entirely, install the _G fallback — without
+        // it every bare global read inside the mod would return nil.
+        lua_getfield(L, -1, "__index");       // [Mods, E, mt, __index]
+        if (lua_isnil(L, -1)) {
+            lua_pop(L, 1);                    // [Mods, E, mt]
+            lua_pushglobaltable(L);           // [Mods, E, mt, _G]
+            lua_setfield(L, -2, "__index");   // mt.__index = _G
+            lua_pop(L, 1);                    // [Mods, E]
+        } else {
+            lua_pop(L, 2);                    // [Mods, E]
+        }
     } else {
         lua_newtable(L);                      // [Mods, E, mt]
         lua_pushglobaltable(L);               // [Mods, E, mt, _G]
@@ -807,6 +818,9 @@ static int require_resolve(lua_State *L, const char *path) {
  */
 static int lua_ext_require(lua_State *L) {
     const char *path = luaL_checkstring(L, 1);
+    // require_finish assumes module returns start at index 2 — drop any extra
+    // caller arguments so they can't be cached as the module value.
+    lua_settop(L, 1);
     LOG_LUA_INFO("Ext.Require('%s')", path);
     return require_resolve(L, path);
 }
@@ -819,6 +833,7 @@ static int lua_ext_require(lua_State *L) {
  */
 static int lua_require(lua_State *L) {
     const char *name = luaL_checkstring(L, 1);
+    lua_settop(L, 1);   // see lua_ext_require: extras must not reach the cache
     char rel[MAX_PATH_LEN];
     size_t n = strlen(name);
     int has_lua = (n >= 4 && strcmp(name + n - 4, ".lua") == 0);
@@ -839,7 +854,18 @@ static int lua_require(lua_State *L) {
     }
 
     LOG_LUA_INFO("require('%s') -> %s", name, rel);
-    return require_resolve(L, rel);
+    require_resolve(L, rel);
+
+    // Mod-relative resolution missed. Fall through to the stock Lua require
+    // (kept as upvalue 1) so package.preload/searchers still work and a truly
+    // missing module raises the standard error instead of returning nil.
+    if (lua_isnil(L, -1) && lua_isfunction(L, lua_upvalueindex(1))) {
+        lua_pop(L, 1);
+        lua_pushvalue(L, lua_upvalueindex(1));
+        lua_pushvalue(L, 1);
+        lua_call(L, 1, 1);
+    }
+    return 1;
 }
 
 // ============================================================================
@@ -1310,15 +1336,17 @@ static int lua_osi_qry_startdialog_fixed(lua_State *L) {
                 int result = osiris_query_by_id(funcId, args);
                 LOG_LUA_INFO("Osi.QRY_StartDialog_Fixed('%s', '%s') -> %d (via Osiris)",
                            resource, character, result);
-                lua_pushboolean(L, result);
+                // Integer 0/1 like every other pure test query (Windows parity;
+                // generic dispatch switched in the PR #93 integration).
+                lua_pushinteger(L, result ? 1 : 0);
                 return 1;
             }
         }
     }
 
-    LOG_LUA_INFO("Osi.QRY_StartDialog_Fixed('%s', '%s') -> false (fallback)",
+    LOG_LUA_INFO("Osi.QRY_StartDialog_Fixed('%s', '%s') -> 0 (fallback)",
                 resource ? resource : "nil", character ? character : "nil");
-    lua_pushboolean(L, 0);
+    lua_pushinteger(L, 0);
     return 1;
 }
 
@@ -1449,8 +1477,10 @@ static void osi_push_typed_value(lua_State *L, mach_vm_address_t tv) {
  *   node   = *( *(factory+0x08) + (nodeId-1)*8 ); dbId = *(node+0x18);
  *   dbmgr  = *(base+0x9f5b0);  db = *( *(dbmgr+0x08) + (dbId-1)*8 ) (CReteDBase);
  *   colCount = *(db+0x40); facts list @ db+0x10 sentinel, begin=*(db+0x18),
- *   node.next @ +0x08, CTuple @ node+0x10, CTuple.values = *(CTuple+0x00),
- *   column i COsiTypedValue @ values + i*0x10.
+ *   node.next @ +0x08, CTuple @ node+0x10. CTuple is a
+ *   COsiSOOList<COsiTypedValue,8> (size @ +0x80, cap @ +0x84): values are
+ *   inline at the tuple base when cap < 9, else *(tuple+0x00) is a heap
+ *   pointer. Column i COsiTypedValue @ values + i*0x10.
  */
 static int osi_db_read_facts(lua_State *L, void *def) {
     int nfilter = lua_gettop(L) - 1;      /* filter args at stack 2..top */
@@ -1470,14 +1500,21 @@ static int osi_db_read_facts(lua_State *L, void *def) {
     uint32_t nodeId = 0;
     if (!safe_memory_read_u32((mach_vm_address_t)def + 0x20, &nodeId) || nodeId == 0) return 1;
 
-    /* def -> node via node factory vector (id-1 index; validate node id). */
-    void *fbegin = NULL, *node = NULL;
+    /* def -> node via node factory vector (id-1 index, bounds-checked against
+     * the vector end pointer at +0x10; validate node id). */
+    void *fbegin = NULL, *fend = NULL, *node = NULL;
     if (!safe_memory_read_pointer((mach_vm_address_t)factory + 0x08, &fbegin) || !fbegin) return 1;
+    safe_memory_read_pointer((mach_vm_address_t)factory + 0x10, &fend);
+    if (fend && (uintptr_t)nodeId > ((uintptr_t)fend - (uintptr_t)fbegin) / 8) {
+        LOG_OSIRIS_WARN("Osi DB: node id %u beyond factory vector", nodeId);
+        return 1;
+    }
     if (!safe_memory_read_pointer((mach_vm_address_t)fbegin + (uintptr_t)(nodeId - 1) * 8, &node) || !node) return 1;
     uint32_t nodeChk = 0;
     safe_memory_read_u32((mach_vm_address_t)node + 0x08, &nodeChk);
     if (nodeChk != nodeId) {
-        LOG_OSIRIS_DEBUG("Osi DB: node id mismatch (%u != %u)", nodeChk, nodeId);
+        LOG_OSIRIS_WARN("Osi DB: node id mismatch (%u != %u) — stale def or "
+                        "layout drift after game update", nodeChk, nodeId);
         return 1;
     }
 
@@ -1485,20 +1522,27 @@ static int osi_db_read_facts(lua_State *L, void *def) {
     if (!safe_memory_read_u32((mach_vm_address_t)node + 0x18, &dbId) || dbId == 0) return 1;
 
     /* node -> CReteDBase via databases vector (id-1 index; validate db id). */
-    void *dbegin = NULL, *db = NULL;
+    void *dbegin = NULL, *dend = NULL, *db = NULL;
     if (!safe_memory_read_pointer((mach_vm_address_t)dbmgr + 0x08, &dbegin) || !dbegin) return 1;
+    safe_memory_read_pointer((mach_vm_address_t)dbmgr + 0x10, &dend);
+    if (dend && (uintptr_t)dbId > ((uintptr_t)dend - (uintptr_t)dbegin) / 8) {
+        LOG_OSIRIS_WARN("Osi DB: db id %u beyond dbase vector", dbId);
+        return 1;
+    }
     if (!safe_memory_read_pointer((mach_vm_address_t)dbegin + (uintptr_t)(dbId - 1) * 8, &db) || !db) return 1;
     uint32_t dbChk = 0;
     safe_memory_read_u32((mach_vm_address_t)db + 0x00, &dbChk);
     if (dbChk != dbId) {
-        LOG_OSIRIS_DEBUG("Osi DB: database id mismatch (%u != %u)", dbChk, dbId);
+        LOG_OSIRIS_WARN("Osi DB: database id mismatch (%u != %u) — stale def or "
+                        "layout drift after game update", dbChk, dbId);
         return 1;
     }
 
     uint8_t colCount = 0;
     safe_memory_read_u8((mach_vm_address_t)db + 0x40, &colCount);
     if (colCount == 0 || colCount > 32) {
-        LOG_OSIRIS_DEBUG("Osi DB: implausible column count %u", colCount);
+        LOG_OSIRIS_WARN("Osi DB: implausible column count %u — layout drift "
+                        "after game update?", colCount);
         return 1;
     }
 
@@ -1511,22 +1555,41 @@ static int osi_db_read_facts(lua_State *L, void *def) {
     while (cur && (mach_vm_address_t)cur != sentinel && rowCount < 100000 && guard < 500000) {
         guard++;
 
-        void *values = NULL;   /* CTuple.values = *(node+0x10) */
-        safe_memory_read_pointer((mach_vm_address_t)cur + 0x10, &values);
+        /* CTuple (inline at node+0x10) is a COsiSOOList<COsiTypedValue,8>:
+         * size @ +0x80, cap @ +0x84; values are stored INLINE at the tuple
+         * base when cap < 9, else the tuple base holds a heap pointer. */
+        mach_vm_address_t tuple = (mach_vm_address_t)cur + 0x10;
+        uint32_t tsize = 0, tcap = 0;
+        safe_memory_read_u32(tuple + 0x80, &tsize);
+        safe_memory_read_u32(tuple + 0x84, &tcap);
+        mach_vm_address_t values = 0;
+        if (tcap >= 9) {
+            void *heap = NULL;
+            safe_memory_read_pointer(tuple, &heap);
+            values = (mach_vm_address_t)heap;
+        } else {
+            values = tuple;
+        }
 
-        int match = (values != NULL);
+        int match = (values != 0 && tsize >= colCount);
         for (int i = 0; i < nfilter && match; i++) {
             int slot = 2 + i;
             if (lua_isnil(L, slot)) continue;      /* wildcard */
             if ((uint32_t)i >= colCount) { match = 0; break; }
-            mach_vm_address_t tv = (mach_vm_address_t)values + (mach_vm_address_t)i * 0x10;
+            mach_vm_address_t tv = values + (mach_vm_address_t)i * 0x10;
             uint16_t colType = 0;
             safe_memory_read(tv + 0x08, &colType, sizeof(colType));
             if (lua_type(L, slot) == LUA_TNUMBER) {
-                int64_t want = (int64_t)lua_tointeger(L, slot), got;
-                if (colType == OSI_TYPE_INTEGER) { uint32_t v = 0; safe_memory_read_u32(tv, &v); got = (int32_t)v; }
-                else { uint64_t v = 0; safe_memory_read_u64(tv, &v); got = (int64_t)v; }
-                if (got != want) match = 0;
+                if (colType == OSI_TYPE_REAL) {
+                    uint32_t v = 0; safe_memory_read_u32(tv, &v);
+                    float f; memcpy(&f, &v, sizeof(f));
+                    if ((lua_Number)f != lua_tonumber(L, slot)) match = 0;
+                } else {
+                    int64_t want = (int64_t)lua_tointeger(L, slot), got;
+                    if (colType == OSI_TYPE_INTEGER) { uint32_t v = 0; safe_memory_read_u32(tv, &v); got = (int32_t)v; }
+                    else { uint64_t v = 0; safe_memory_read_u64(tv, &v); got = (int64_t)v; }
+                    if (got != want) match = 0;
+                }
             } else {
                 const char *want = lua_tostring(L, slot);
                 uint64_t handle = 0; char buf[256]; buf[0] = '\0';
@@ -1539,7 +1602,7 @@ static int osi_db_read_facts(lua_State *L, void *def) {
         if (match) {
             lua_newtable(L);                        /* row */
             for (uint32_t i = 0; i < colCount; i++) {
-                osi_push_typed_value(L, (mach_vm_address_t)values + (mach_vm_address_t)i * 0x10);
+                osi_push_typed_value(L, values + (mach_vm_address_t)i * 0x10);
                 lua_rawseti(L, -2, (int)i + 1);
             }
             rowCount++;
@@ -1715,15 +1778,22 @@ static int osi_value_to_lua(lua_State *L, OsiArgumentValue *val) {
             return 1;
         case OSI_TYPE_STRING:
         case OSI_TYPE_GUIDSTRING:
-        default:
+        default: {
             // STRING/GUIDSTRING and all custom GUID subtypes (CHARACTERGUID,
             // ITEMGUID, ... typeId > 5) carry a char* value from the engine.
-            if (val->stringVal) {
-                lua_pushstring(L, val->stringVal);
+            // Copy through safe_memory so a garbage pointer (type-guess
+            // mismatch, engine layout drift) yields "" instead of a SIGSEGV
+            // inside lua_pushstring's strlen.
+            char buf[512];
+            if (val->stringVal &&
+                safe_memory_read_string((mach_vm_address_t)(uintptr_t)val->stringVal,
+                                        buf, sizeof(buf))) {
+                lua_pushstring(L, buf);
             } else {
                 lua_pushstring(L, "");
             }
             return 1;
+        }
     }
 }
 
@@ -2326,8 +2396,11 @@ static void register_global_functions(lua_State *L) {
 
     // Override the stock Lua require with a mod-aware loader so mods that use
     // bare require("Some/Module") (MCM, CommunityLibrary) resolve against the
-    // current mod's Script Extender Lua folder.
-    lua_pushcfunction(L, lua_require);
+    // current mod's Script Extender Lua folder. The stock require is kept as
+    // upvalue 1 so misses fall through to package.preload/searchers and raise
+    // the standard "module not found" error instead of returning nil.
+    lua_getglobal(L, "require");
+    lua_pushcclosure(L, lua_require, 1);
     lua_setglobal(L, "require");
 
     LOG_LUA_INFO("Global functions registered (_P, _D, require)");
@@ -2479,11 +2552,15 @@ static void load_mod_scripts(lua_State *L) {
         lua_pushstring(L, (mod_uuid && mod_uuid[0]) ? mod_uuid : "");
         lua_setglobal(L, "ModuleUUID");
 
-        // Load server bootstrap in SERVER context
+        // Load server bootstrap in SERVER context. Bootstraps run with
+        // LUA_MULTRET (shared loader with require) — drop any values a
+        // top-level script happens to return so they can't pile up here.
+        int stack_base = lua_gettop(L);
         if (load_mod_bootstrap(L, mod_dir, "Server") > 0) {
             LOG_LUA_INFO("Loaded BootstrapServer.lua for: %s (context=Server)",
                          mod_get_se_name(i));
         }
+        lua_settop(L, stack_base);
     }
 
     // Phase 2: Load all client bootstraps (in CLIENT context)
@@ -2507,12 +2584,22 @@ static void load_mod_scripts(lua_State *L) {
         lua_pushstring(L, (mod_uuid && mod_uuid[0]) ? mod_uuid : "");
         lua_setglobal(L, "ModuleUUID");
 
-        // Load client bootstrap in CLIENT context
+        // Load client bootstrap in CLIENT context (stack discipline as above)
+        int stack_base = lua_gettop(L);
         if (load_mod_bootstrap(L, mod_dir, "Client") > 0) {
             LOG_LUA_INFO("Loaded BootstrapClient.lua for: %s (context=Client)",
                          mod_get_se_name(i));
         }
+        lua_settop(L, stack_base);
     }
+
+    // Clear the per-mod loader state: without this, the last-loaded mod's
+    // environment, current-mod paths, and ModuleUUID leak into everything that
+    // runs afterwards (console Ext.Require would resolve as that mod).
+    mod_env_set(L, NULL, NULL);
+    mod_set_current(NULL, NULL, NULL);
+    lua_pushnil(L);
+    lua_setglobal(L, "ModuleUUID");
 
     // Stay in CLIENT context after loading (we're on a client machine)
     LOG_MOD_INFO("=== Mod Script Loading Complete (final context=Client) ===");
@@ -3176,8 +3263,23 @@ static int osi_read_param_defs(uint32_t handle, OsiParamDef *defs, int maxDefs) 
     for (uint32_t i = 0; i < pcount && (int)i < maxDefs; i++) {
         mach_vm_address_t p = (mach_vm_address_t)params + (mach_vm_address_t)i * 0x10;
         uint32_t type = 0, dir = 0;
-        safe_memory_read_u32(p + 0x08, &type);
-        safe_memory_read_u32(p + 0x0c, &dir);
+        // Both reads must succeed and the direction must be a real Osiris
+        // direction (1=in, 2=out). A failed read leaves type=0/dir=0, which the
+        // dispatcher would treat as an OSI_TYPE_NONE input and hand to strict
+        // engine dispatch (C++ exception/SIGABRT). Fail the whole lookup
+        // instead — the caller falls back to legacy arity-based guessing.
+        if (!safe_memory_read_u32(p + 0x08, &type) ||
+            !safe_memory_read_u32(p + 0x0c, &dir) ||
+            type == 0 || (dir != 1 && dir != 2)) {
+            static int warned_once = 0;
+            if (!warned_once) {
+                warned_once = 1;
+                LOG_OSIRIS_WARN("osi_read_param_defs: invalid param def "
+                                "(type=%u dir=%u) — falling back to legacy "
+                                "dispatch for this session", type, dir);
+            }
+            return -1;
+        }
         defs[i].type = type;
         defs[i].direction = (uint8_t)dir;
     }
@@ -3668,12 +3770,19 @@ after_tick:
     // never resolve them and returns empty (breaking mods like Sit This One Out
     // whose grant loops iterate DB_PartyMembers). SavegameLoaded and
     // LevelGameplayStarted fire after story load, so walk the name index here
-    // BEFORE dispatching to Lua callbacks. One-shot flag: run once per session
-    // (not on every level transition); the walk is idempotent and read-only.
+    // BEFORE dispatching to Lua callbacks. SavegameLoaded always re-walks
+    // (loading another save rebuilds the story, leaving the registry's
+    // COsiFunctionData* pointers stale); LevelGameplayStarted only fills the
+    // registry the first time. The walk is idempotent and read-only.
     static int g_dbNamesEnumerated = 0;
-    if (!g_dbNamesEnumerated && funcName &&
-        (strcmp(funcName, "SavegameLoaded") == 0 ||
-         strcmp(funcName, "LevelGameplayStarted") == 0)) {
+    if (funcName && strcmp(funcName, "SavegameLoaded") == 0) {
+        osi_db_clear();
+        g_dbNamesEnumerated = 1;
+        LOG_OSIRIS_INFO("Story loaded (%s) — walking Osiris name index to "
+                        "discover databases", funcName);
+        osi_func_enumerate_by_name();
+    } else if (!g_dbNamesEnumerated && funcName &&
+               strcmp(funcName, "LevelGameplayStarted") == 0) {
         g_dbNamesEnumerated = 1;
         LOG_OSIRIS_INFO("Story loaded (%s) — walking Osiris name index to "
                         "discover databases", funcName);

--- a/src/input/focusless_input.m
+++ b/src/input/focusless_input.m
@@ -142,15 +142,31 @@ static bool try_direct_view_mouse_click(double x_fraction, double y_fraction_top
     NSWindow *win = [view window];
     NSInteger winNum = win ? [win windowNumber] : 0;
     NSRect bounds = [view bounds];
-    CGFloat x = NSMinX(bounds) + NSWidth(bounds) * x_fraction;
-    CGFloat y = NSMinY(bounds) + NSHeight(bounds) * (1.0 - y_fraction_top_origin);
-    NSPoint location = NSMakePoint(x, y);
+    CGFloat vx = NSMinX(bounds) + NSWidth(bounds) * x_fraction;
+    CGFloat vy = [view isFlipped]
+        ? NSMinY(bounds) + NSHeight(bounds) * y_fraction_top_origin
+        : NSMinY(bounds) + NSHeight(bounds) * (1.0 - y_fraction_top_origin);
+    // NSEvent locations are window-base coordinates. BG3's mouseDown: input
+    // record carries no coordinates at all — Noesis hit-tests against the
+    // engine cursor state established by the preceding mouseMoved:, so the
+    // moved event must land exactly where the click should.
+    NSPoint location = [view convertPoint:NSMakePoint(vx, vy) toView:nil];
     NSTimeInterval now = [[NSProcessInfo processInfo] systemUptime];
+
+    NSEvent *move = [NSEvent mouseEventWithType:NSEventTypeMouseMoved
+                                       location:location
+                                  modifierFlags:0
+                                      timestamp:now
+                                   windowNumber:winNum
+                                        context:nil
+                                    eventNumber:0
+                                     clickCount:0
+                                       pressure:0.0];
 
     NSEvent *down = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
                                        location:location
                                   modifierFlags:0
-                                      timestamp:now
+                                      timestamp:now + 0.02
                                    windowNumber:winNum
                                         context:nil
                                     eventNumber:0
@@ -167,9 +183,9 @@ static bool try_direct_view_mouse_click(double x_fraction, double y_fraction_top
                                    clickCount:1
                                      pressure:0.0];
 
-    LOG_CORE_DEBUG("[FocuslessInput] Calling [LSMTLView mouseDown:] x=%.1f y=%.1f xf=%.3f yf=%.3f inputMgr=%p win=%ld",
-                  x, y, x_fraction, y_fraction_top_origin, inputMgr, (long)winNum);
-    [view mouseMoved:down];
+    LOG_CORE_DEBUG("[FocuslessInput] Calling [LSMTLView mouseDown:] winloc=(%.1f, %.1f) xf=%.3f yf=%.3f inputMgr=%p win=%ld",
+                  location.x, location.y, x_fraction, y_fraction_top_origin, inputMgr, (long)winNum);
+    [view mouseMoved:move];
     [view mouseDown:down];
     [view mouseUp:up];
     return true;

--- a/src/input/focusless_input.m
+++ b/src/input/focusless_input.m
@@ -19,6 +19,7 @@
 
 #include "focusless_input.h"
 #include "../core/logging.h"
+#include "../game/game_state.h"
 #include "../imgui/imgui_metal_backend.h"
 
 static bool s_initialized = false;
@@ -225,9 +226,18 @@ void focusless_input_start_splash_autodismiss(double duration, double interval) 
                               interval_ns, interval_ns / 10);
 
     dispatch_source_set_event_handler(s_splash_timer, ^{
-        if (s_socket_ready || s_dismiss_count >= s_max_dismiss) {
+        // Stop once the game has actually advanced past the splash (a session
+        // is loading or running) — NOT on socket traffic: the harness polls
+        // !identity during boot, which previously cancelled us at 0 attempts.
+        ServerGameState gs = game_state_get_current();
+        bool past_splash = (gs >= SERVER_STATE_LOAD_LEVEL &&
+                            gs <= SERVER_STATE_RUNNING);
+        if (s_socket_ready || past_splash || s_dismiss_count >= s_max_dismiss) {
             LOG_CORE_INFO("[FocuslessInput] Splash timer stopped (%s, %d attempts)",
-                          s_socket_ready ? "socket ready" : "max reached", s_dismiss_count);
+                          s_socket_ready ? "explicit stop"
+                                         : past_splash ? "game state advanced"
+                                                       : "max reached",
+                          s_dismiss_count);
             dispatch_source_cancel(s_splash_timer);
             s_splash_timer = NULL;
             return;

--- a/src/level/level_manager.c
+++ b/src/level/level_manager.c
@@ -15,15 +15,14 @@
 #include "level_manager.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/offset_table.h"
 #include <string.h>
 
 // ============================================================================
 // Constants and Offsets
 // ============================================================================
 
-// LevelManager::m_ptr global singleton
-// Same address used in template_manager.c
-#define OFFSET_LEVEL_MANAGER_PTR    0x08a3be40
+// LevelManager::m_ptr — sourced from offset_table at runtime
 
 // LevelManager internal offsets (need ARM64 runtime verification)
 #define LEVELMANAGER_CURRENT_LEVEL_OFFSET   0x90   // EoCLevel* CurrentLevel
@@ -76,12 +75,20 @@ bool level_manager_init(void *main_binary_base) {
     }
 
     g_level.main_binary_base = main_binary_base;
-    g_level.level_manager_ptr = (void **)((uintptr_t)main_binary_base + OFFSET_LEVEL_MANAGER_PTR);
+
+    const VersionOffsets *off = offset_table_get();
+    if (!off || !off->level_mgr_ptr) {
+        log_message("[Level] WARN: level_mgr_ptr not available for this BG3 version — Level API disabled");
+        g_level.initialized = true;
+        return true;  // Not a fatal error; Level APIs will return NULL gracefully
+    }
+
+    g_level.level_manager_ptr = (void **)offset_table_resolve(off->level_mgr_ptr);
 
     log_message("[Level] Level manager initialized");
     log_message("[Level]   Base: %p", main_binary_base);
-    log_message("[Level]   LevelManager::m_ptr at offset 0x%x -> %p",
-                OFFSET_LEVEL_MANAGER_PTR, (void *)g_level.level_manager_ptr);
+    log_message("[Level]   LevelManager::m_ptr at offset 0x%llx -> %p",
+                (unsigned long long)off->level_mgr_ptr, (void *)g_level.level_manager_ptr);
 
     g_level.initialized = true;
     return true;

--- a/src/localization/localization.c
+++ b/src/localization/localization.c
@@ -20,6 +20,7 @@
 #include "localization.h"
 #include "logging.h"
 #include "fixed_string.h"
+#include "../core/offset_table.h"
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -133,13 +134,21 @@ void localization_init(void *main_binary_base) {
 
     s_loca.binary_base = main_binary_base;
 
-    // Calculate address of ls::TranslatedStringRepository::m_ptr
-    s_loca.repo_ptr_addr = (void**)((uintptr_t)main_binary_base + LOCA_REPO_OFFSET);
+    // The repository m_ptr is a __DATA global -> apply the per-version data shift.
+    const VersionOffsets *vo = offset_table_get();
+    uintptr_t data_shift = vo ? vo->component_data_shift : 0;
+    s_loca.repo_ptr_addr = (void**)((uintptr_t)main_binary_base + LOCA_REPO_OFFSET + data_shift);
 
-    // Calculate function addresses
-    s_loca.fs_create = (FixedStringCreateFn)((uintptr_t)main_binary_base + LOCA_FIXEDSTRING_CREATE);
-    s_loca.tryget_fn = (void*)((uintptr_t)main_binary_base + LOCA_TRYGET_OFFSET);
-    s_loca.add_string_fn = (AddTranslatedStringFn)((uintptr_t)main_binary_base + LOCA_ADDTRANSLATEDSTRING);
+    // The functions are __TEXT -> remap each hardcoded 6995620 address. If a
+    // function has no verified address for this version, leave it NULL so the
+    // caller skips it instead of jumping to a stale address.
+    #define LOCA_FN(off) ({ \
+        uint64_t _a = offset_table_remap_fn(0x100000000ULL + (off)); \
+        _a ? (void*)((uintptr_t)main_binary_base + (_a - 0x100000000ULL)) : NULL; })
+    s_loca.fs_create     = (FixedStringCreateFn)LOCA_FN(LOCA_FIXEDSTRING_CREATE);
+    s_loca.tryget_fn     = LOCA_FN(LOCA_TRYGET_OFFSET);
+    s_loca.add_string_fn = (AddTranslatedStringFn)LOCA_FN(LOCA_ADDTRANSLATEDSTRING);
+    #undef LOCA_FN
 
     LOG_CORE_INFO("LOCA: Initialized - repo_ptr at %p", (void*)s_loca.repo_ptr_addr);
     LOG_CORE_DEBUG("LOCA: FixedString::Create at %p", (void*)s_loca.fs_create);

--- a/src/localization/localization.c
+++ b/src/localization/localization.c
@@ -32,14 +32,17 @@
 // Offset Constants (macOS ARM64)
 // ============================================================================
 
-// TranslatedStringRepository::m_ptr offset from main binary base
-#define LOCA_REPO_OFFSET  0x8aed088
+// ls::TranslatedStringRepository::m_ptr offset from main binary base.
+// 4.1.1.7209685 vintage, nm-verified (0x108af5088 b TranslatedStringRepository::m_ptr).
+// Older versions are reached via VersionOffsets.component_data_shift.
+#define LOCA_REPO_OFFSET  0x8af5088
 
-// Function offsets (from Ghidra analysis, Dec 2025)
-// These are absolute Ghidra addresses - need to subtract base
-#define LOCA_TRYGET_OFFSET          0x6534d54   // TryGet function
-#define LOCA_FIXEDSTRING_CREATE     0x64b9ebc   // ls::FixedString::Create(char*, int)
-#define LOCA_ADDTRANSLATEDSTRING    0x6532590   // AddTranslatedString(handle, value)
+// Function offsets — 4.1.1.7209685 vintage, nm-verified. Passed through
+// offset_table_remap_fn(), which matches either vintage column and fails
+// closed (NULL fn) on unknown versions.
+#define LOCA_TRYGET_OFFSET          0x652390c   // ls::TranslatedStringRepository::TryGet
+#define LOCA_FIXEDSTRING_CREATE     0x64a8a74   // ls::FixedString::Create(char*, int)
+#define LOCA_ADDTRANSLATEDSTRING    0x6521148   // AddTranslatedString(handle, value)
 
 // TranslatedStringRepository structure offsets (to be verified)
 // These are estimated from Windows x64 - may need ARM64 adjustment
@@ -134,14 +137,20 @@ void localization_init(void *main_binary_base) {
 
     s_loca.binary_base = main_binary_base;
 
-    // The repository m_ptr is a __DATA global -> apply the per-version data shift.
+    // The repository m_ptr is a __DATA global (7209685-vintage constant) ->
+    // apply the signed per-version data shift. No table row -> fail closed.
     const VersionOffsets *vo = offset_table_get();
-    uintptr_t data_shift = vo ? vo->component_data_shift : 0;
+    if (!vo) {
+        LOG_CORE_INFO("LOCA: No offset-table row for this game version — localization disabled");
+        s_loca.initialized = true;  // don't retry; ready() stays false (repo_ptr_addr NULL)
+        return;
+    }
+    intptr_t data_shift = vo->component_data_shift;
     s_loca.repo_ptr_addr = (void**)((uintptr_t)main_binary_base + LOCA_REPO_OFFSET + data_shift);
 
-    // The functions are __TEXT -> remap each hardcoded 6995620 address. If a
-    // function has no verified address for this version, leave it NULL so the
-    // caller skips it instead of jumping to a stale address.
+    // The functions are __TEXT -> remap each hardcoded address (either vintage).
+    // If a function has no verified address for this version, leave it NULL so
+    // the caller skips it instead of jumping to a stale address.
     #define LOCA_FN(off) ({ \
         uint64_t _a = offset_table_remap_fn(0x100000000ULL + (off)); \
         _a ? (void*)((uintptr_t)main_binary_base + (_a - 0x100000000ULL)) : NULL; })

--- a/src/lua/lua_events.c
+++ b/src/lua/lua_events.c
@@ -536,19 +536,28 @@ static const char *server_state_to_ecl_label(int s) {
 // never equals the EnumValue. So we must hand back the same userdata. Falls back
 // to the ecl integer if the enum isn't available.
 void events_push_client_gamestate(lua_State *L, int internal_state) {
+    // Every lua_getfield target must be type-checked: this runs during event
+    // construction BEFORE the handler's lua_pcall, so an "attempt to index
+    // nil" here would hit the panic handler and abort the process.
     const char *label = server_state_to_ecl_label(internal_state);
     if (label) {
-        lua_getglobal(L, "Ext");                 // Ext
-        lua_getfield(L, -1, "Enums");            // Ext, Enums
-        lua_getfield(L, -1, "ClientGameState");  // Ext, Enums, CGS
-        lua_getfield(L, -1, label);              // Ext, Enums, CGS, val
-        if (!lua_isnil(L, -1)) {
-            lua_remove(L, -2);                   // Ext, Enums, val
-            lua_remove(L, -2);                   // Ext, val
-            lua_remove(L, -2);                   // val
-            return;
+        int base = lua_gettop(L);
+        lua_getglobal(L, "Ext");                     // Ext
+        if (lua_istable(L, -1)) {
+            lua_getfield(L, -1, "Enums");            // Ext, Enums
+            if (lua_istable(L, -1) || lua_isuserdata(L, -1)) {
+                lua_getfield(L, -1, "ClientGameState");  // Ext, Enums, CGS
+                if (lua_istable(L, -1) || lua_isuserdata(L, -1)) {
+                    lua_getfield(L, -1, label);      // Ext, Enums, CGS, val
+                    if (!lua_isnil(L, -1)) {
+                        lua_insert(L, base + 1);     // val, Ext, Enums, CGS
+                        lua_settop(L, base + 1);     // val
+                        return;
+                    }
+                }
+            }
         }
-        lua_pop(L, 4);
+        lua_settop(L, base);
     }
     lua_pushinteger(L, server_state_to_ecl(internal_state));
 }

--- a/src/lua/lua_events.c
+++ b/src/lua/lua_events.c
@@ -128,6 +128,9 @@ static const char *g_event_names[EVENT_MAX] = {
     "SpellCastPrepareStart",
     "SpellCastPrepareEnd",
     "SpellCastPreviewEnd",
+    // Client input events (needed by MCM's SubscribedEvents)
+    "ControllerButtonInput",
+    "MouseButtonInput",
 };
 
 // ============================================================================
@@ -480,6 +483,76 @@ void events_fire_tick(lua_State *L, float delta_time) {
 // Public API: Fire GameStateChanged Event (with FromState and ToState)
 // ============================================================================
 
+// The port infers a generic ServerGameState (game_state.c), but mods subscribe
+// in client context and compare e.ToState against Ext.Enums.ClientGameState
+// (ecl::GameState). Those enums use DIFFERENT numeric values (e.g. Running is
+// 13 internally but 18 in ecl, and the main menu is Idle=3 internally but
+// Menu=7 in ecl). Map to ecl values so MCM's `e.ToState == ClientGameState.X`
+// checks match — otherwise its client init (which builds the settings window)
+// never fires. Unmapped states pass through unchanged.
+static int server_state_to_ecl(int s) {
+    switch (s) {
+        case 2:  return 1;   // Init          -> Init
+        case 3:  return 7;   // Idle          -> Menu (main menu)
+        case 4:  return 8;   // Exit          -> Exit
+        case 5:  return 10;  // LoadLevel     -> LoadLevel
+        case 6:  return 11;  // LoadModule    -> LoadModule
+        case 7:  return 12;  // LoadSession   -> LoadSession
+        case 8:  return 13;  // UnloadLevel   -> UnloadLevel
+        case 9:  return 14;  // UnloadModule  -> UnloadModule
+        case 10: return 15;  // UnloadSession -> UnloadSession
+        case 12: return 16;  // Paused        -> Paused
+        case 13: return 18;  // Running       -> Running
+        case 14: return 21;  // Save          -> Save
+        case 15: return 19;  // Disconnect    -> Disconnect
+        default: return s;   // Unknown(0) and any others pass through
+    }
+}
+
+// ecl::GameState label for an internal ServerGameState (NULL if none).
+static const char *server_state_to_ecl_label(int s) {
+    switch (s) {
+        case 0:  return "Unknown";
+        case 2:  return "Init";
+        case 3:  return "Menu";          // main menu
+        case 4:  return "Exit";
+        case 5:  return "LoadLevel";
+        case 6:  return "LoadModule";
+        case 7:  return "LoadSession";
+        case 8:  return "UnloadLevel";
+        case 9:  return "UnloadModule";
+        case 10: return "UnloadSession";
+        case 12: return "Paused";
+        case 13: return "Running";
+        case 14: return "Save";
+        case 15: return "Disconnect";
+        default: return NULL;
+    }
+}
+
+// Push the matching Ext.Enums.ClientGameState EnumValue *userdata* for an internal
+// state. Mods compare e.ToState with `==` against Ext.Enums.ClientGameState.X,
+// and Lua only invokes __eq between two userdata of the same type — an integer
+// never equals the EnumValue. So we must hand back the same userdata. Falls back
+// to the ecl integer if the enum isn't available.
+void events_push_client_gamestate(lua_State *L, int internal_state) {
+    const char *label = server_state_to_ecl_label(internal_state);
+    if (label) {
+        lua_getglobal(L, "Ext");                 // Ext
+        lua_getfield(L, -1, "Enums");            // Ext, Enums
+        lua_getfield(L, -1, "ClientGameState");  // Ext, Enums, CGS
+        lua_getfield(L, -1, label);              // Ext, Enums, CGS, val
+        if (!lua_isnil(L, -1)) {
+            lua_remove(L, -2);                   // Ext, Enums, val
+            lua_remove(L, -2);                   // Ext, val
+            lua_remove(L, -2);                   // val
+            return;
+        }
+        lua_pop(L, 4);
+    }
+    lua_pushinteger(L, server_state_to_ecl(internal_state));
+}
+
 void events_fire_game_state_changed(lua_State *L, int fromState, int toState) {
     // Cache the current game state for Ext.Utils.GetGameState()
     g_current_game_state = toState;
@@ -514,11 +587,12 @@ void events_fire_game_state_changed(lua_State *L, int fromState, int toState) {
             continue;
         }
 
-        // Create event data table with FromState and ToState
+        // Create event data table with FromState and ToState as ClientGameState
+        // EnumValue userdata (so `e.ToState == Ext.Enums.ClientGameState.X` works).
         lua_newtable(L);
-        lua_pushinteger(L, fromState);
+        events_push_client_gamestate(L,fromState);
         lua_setfield(L, -2, "FromState");
-        lua_pushinteger(L, toState);
+        events_push_client_gamestate(L,toState);
         lua_setfield(L, -2, "ToState");
 
         // Protected call
@@ -554,6 +628,49 @@ int events_get_current_game_state(void) {
     return g_current_game_state;
 }
 
+// Map a macOS virtual keycode (kVK_*) to the SDL scancode NAME string that
+// Windows BG3SE puts in KeyInputEvent.Key (see GameDefinitions/Enumerations/
+// IMGUI.inl SDLScanCode enum). Mods (MCM keybindings, e.Key == "ESCAPE", etc.)
+// compare against these names, so the port must deliver names, not raw keycodes.
+static const char *macos_keycode_to_sdl_name(int kc) {
+    switch (kc) {
+        // Letters
+        case 0x00: return "A"; case 0x0B: return "B"; case 0x08: return "C";
+        case 0x02: return "D"; case 0x0E: return "E"; case 0x03: return "F";
+        case 0x05: return "G"; case 0x04: return "H"; case 0x22: return "I";
+        case 0x26: return "J"; case 0x28: return "K"; case 0x25: return "L";
+        case 0x2E: return "M"; case 0x2D: return "N"; case 0x1F: return "O";
+        case 0x23: return "P"; case 0x0C: return "Q"; case 0x0F: return "R";
+        case 0x01: return "S"; case 0x11: return "T"; case 0x20: return "U";
+        case 0x09: return "V"; case 0x0D: return "W"; case 0x07: return "X";
+        case 0x10: return "Y"; case 0x06: return "Z";
+        // Number row
+        case 0x12: return "NUM_1"; case 0x13: return "NUM_2"; case 0x14: return "NUM_3";
+        case 0x15: return "NUM_4"; case 0x17: return "NUM_5"; case 0x16: return "NUM_6";
+        case 0x1A: return "NUM_7"; case 0x1C: return "NUM_8"; case 0x19: return "NUM_9";
+        case 0x1D: return "NUM_0";
+        // Punctuation / symbols
+        case 0x32: return "GRAVE"; case 0x1B: return "MINUS"; case 0x18: return "EQUALS";
+        case 0x21: return "LEFTBRACKET"; case 0x1E: return "RIGHTBRACKET";
+        case 0x2A: return "BACKSLASH"; case 0x29: return "SEMICOLON";
+        case 0x27: return "APOSTROPHE"; case 0x2B: return "COMMA";
+        case 0x2F: return "PERIOD"; case 0x2C: return "SLASH";
+        // Editing / whitespace
+        case 0x24: return "RETURN"; case 0x30: return "TAB"; case 0x31: return "SPACE";
+        case 0x33: return "BACKSPACE"; case 0x35: return "ESCAPE"; case 0x39: return "CAPSLOCK";
+        // Navigation cluster
+        case 0x73: return "HOME"; case 0x77: return "END"; case 0x74: return "PAGEUP";
+        case 0x79: return "PAGEDOWN"; case 0x75: return "DEL";
+        case 0x7B: return "LEFT"; case 0x7C: return "RIGHT"; case 0x7D: return "DOWN"; case 0x7E: return "UP";
+        // Function keys
+        case 0x7A: return "F1"; case 0x78: return "F2"; case 0x63: return "F3";
+        case 0x76: return "F4"; case 0x60: return "F5"; case 0x61: return "F6";
+        case 0x62: return "F7"; case 0x64: return "F8"; case 0x65: return "F9";
+        case 0x6D: return "F10"; case 0x67: return "F11"; case 0x6F: return "F12";
+        default: return "UNKNOWN";
+    }
+}
+
 void events_fire_key_input(lua_State *L, int keyCode, bool pressed, int modifiers, const char *character) {
     if (!L) return;
 
@@ -578,14 +695,33 @@ void events_fire_key_input(lua_State *L, int keyCode, bool pressed, int modifier
 
         lua_rawgeti(L, LUA_REGISTRYINDEX, h->callback_ref);
         if (lua_isfunction(L, -1)) {
-            // Create event data table
+            // Create event data table matching Windows BG3SE KeyInputEvent:
+            // { Event="KeyDown"/"KeyUp", Key=<SDL scancode name>, Modifiers,
+            //   Pressed, Repeat }. Mods (MCM keybindings, e.Key=="ESCAPE", the
+            //   e.Event=="KeyDown" guard) rely on this exact shape.
             lua_newtable(L);
-            lua_pushinteger(L, keyCode);
+            lua_pushstring(L, pressed ? "KeyDown" : "KeyUp");
+            lua_setfield(L, -2, "Event");
+            lua_pushstring(L, macos_keycode_to_sdl_name(keyCode));
             lua_setfield(L, -2, "Key");
             lua_pushboolean(L, pressed);
             lua_setfield(L, -2, "Pressed");
-            lua_pushinteger(L, modifiers);
+            lua_pushboolean(L, 0);  // Repeat: not tracked from CGEventTap; treat as non-repeat
+            lua_setfield(L, -2, "Repeat");
+            // Modifiers: an ARRAY of SDL-style modifier NAME strings (MCM's
+            // ExtractActiveModifiers does ipairs over it, so it MUST be a table,
+            // not an integer — an integer errors and breaks keybinding dispatch).
+            // Empty when no modifier is held (the common case, e.g. the toggle key).
+            // Bits are CGEventFlags; we map to the left-hand variants.
+            lua_newtable(L);
+            int mi = 0;
+            if (modifiers & 0x20000)  { lua_pushstring(L, "LSHIFT"); lua_rawseti(L, -2, ++mi); }
+            if (modifiers & 0x40000)  { lua_pushstring(L, "LCTRL");  lua_rawseti(L, -2, ++mi); }
+            if (modifiers & 0x80000)  { lua_pushstring(L, "LALT");   lua_rawseti(L, -2, ++mi); }
             lua_setfield(L, -2, "Modifiers");
+            // Keep the raw keycode + character as extras (harmless; some code reads them).
+            lua_pushinteger(L, keyCode);
+            lua_setfield(L, -2, "KeyCode");
             if (character && character[0]) {
                 lua_pushstring(L, character);
             } else {

--- a/src/lua/lua_events.h
+++ b/src/lua/lua_events.h
@@ -68,6 +68,9 @@ typedef enum {
     EVENT_SPELL_CAST_PREPARE_START,          // Spell prepare phase started
     EVENT_SPELL_CAST_PREPARE_END,            // Spell prepare phase ended
     EVENT_SPELL_CAST_PREVIEW_END,            // Spell preview phase ended
+    // Client input events (needed by MCM's SubscribedEvents)
+    EVENT_CONTROLLER_BUTTON_INPUT,           // Gamepad button input
+    EVENT_MOUSE_BUTTON_INPUT,                // Mouse button input
     EVENT_MAX
 } BG3SEEventType;
 
@@ -114,6 +117,10 @@ void events_fire_tick(lua_State *L, float delta_time);
  * @param toState   New state value
  */
 void events_fire_game_state_changed(lua_State *L, int fromState, int toState);
+
+// Push the Ext.Enums.ClientGameState EnumValue userdata for an internal
+// ServerGameState (used by Ext.Utils.GetGameState so mods can compare it with ==).
+void events_push_client_gamestate(lua_State *L, int internal_state);
 
 /**
  * Fire the KeyInput event with key data.

--- a/src/lua/lua_ext.c
+++ b/src/lua/lua_ext.c
@@ -11,6 +11,8 @@
 #include "logging.h"
 #include "../console/console.h"
 #include "../io/path_override.h"
+#include "../mod/mod_loader.h"
+#include "../pak/pak_reader.h"
 #include "../entity/component_registry.h"
 #include "../entity/component_property.h"
 #include "../enum/enum_registry.h"
@@ -22,6 +24,7 @@
 #include <string.h>
 #include <signal.h>
 #include <setjmp.h>
+#include <sys/stat.h>
 #include <mach-o/dyld.h>
 #include <mach/mach.h>
 #include <mach/vm_map.h>
@@ -80,12 +83,103 @@ int lua_ext_getcontext(lua_State *L) {
 // Ext.IO Functions
 // ============================================================================
 
+// Base directory for Script Extender user data (mod settings, profiles). Mirrors
+// Windows BG3SE's "Script Extender" data folder. MCM persists mod settings and
+// its open_on_start first-run migration here via Ext.IO.SaveFile with a relative
+// path (e.g. "BG3MCM/Profiles/Default/BG3MCM/settings.json"); without a real
+// base those paths resolve against the CWD and the writes fail, so nothing
+// persists (and MCM's window keeps auto-opening every launch).
+static const char *io_se_data_base(void) {
+    static char base[MAX_PATH_LEN];
+    static int inited = 0;
+    if (!inited) {
+        const char *home = getenv("HOME");
+        snprintf(base, sizeof(base),
+                 "%s/Documents/Larian Studios/Baldur's Gate 3/Script Extender",
+                 home ? home : "");
+        inited = 1;
+    }
+    return base;
+}
+
+// Create all parent directories of file_path (mkdir -p on the dirname).
+static void io_mkdir_parents(const char *file_path) {
+    char tmp[MAX_PATH_LEN];
+    snprintf(tmp, sizeof(tmp), "%s", file_path);
+    char *last = strrchr(tmp, '/');
+    if (!last) return;
+    *last = '\0';  // strip filename, leaving the directory path
+    for (char *p = tmp + 1; *p; p++) {
+        if (*p == '/') {
+            *p = '\0';
+            mkdir(tmp, 0755);
+            *p = '/';
+        }
+    }
+    mkdir(tmp, 0755);
+}
+
+// Read a mod-relative VFS path (e.g. "Mods/BG3MCM/ScriptExtender/Config.json")
+// out of the owning mod's PAK. Windows BG3SE's Ext.IO.LoadFile(path, "data")
+// resolves such paths against the game's virtual filesystem, which includes
+// mounted PAKs; the port must do the same so mods like MCM can read their
+// Config.json / JSON blueprints. Returns malloc'd, NUL-terminated content (caller
+// frees) or NULL if not found. *out_size excludes the terminator.
+static char *io_load_from_pak(const char *path, size_t *out_size) {
+    // Only VFS-style "Mods/<Folder>/..." paths live inside PAKs.
+    if (strncmp(path, "Mods/", 5) != 0) return NULL;
+
+    // Extract the mod folder name (between "Mods/" and the next '/').
+    const char *folder_start = path + 5;
+    const char *slash = strchr(folder_start, '/');
+    if (!slash || slash == folder_start) return NULL;
+
+    char folder[256];
+    size_t flen = (size_t)(slash - folder_start);
+    if (flen >= sizeof(folder)) return NULL;
+    memcpy(folder, folder_start, flen);
+    folder[flen] = '\0';
+
+    char pak_path[MAX_PATH_LEN];
+    if (!mod_find_pak(folder, pak_path, sizeof(pak_path))) return NULL;
+
+    PakFile *pak = pak_open(pak_path);
+    if (!pak) return NULL;
+
+    int idx = pak_find_entry(pak, path);
+    if (idx < 0) {
+        pak_close(pak);
+        return NULL;
+    }
+
+    char *content = pak_read_file(pak, idx, out_size);
+    pak_close(pak);
+    return content;  // already NUL-terminated by pak_read_file
+}
+
 int lua_ext_io_loadfile(lua_State *L) {
     const char *path = luaL_checkstring(L, 1);
     LOG_LUA_INFO("Ext.IO.LoadFile('%s')", path);
 
     FILE *f = fopen(path, "r");
+    if (!f && path[0] != '/') {
+        // Relative VFS path: try the Script Extender data dir (user-saved data
+        // like MCM's settings.json lives here — see io_se_data_base).
+        char se_path[MAX_PATH_LEN];
+        snprintf(se_path, sizeof(se_path), "%s/%s", io_se_data_base(), path);
+        f = fopen(se_path, "r");
+    }
     if (!f) {
+        // Filesystem miss: fall back to reading from the owning mod's PAK
+        // (VFS "data" semantics). Required for MCM's reverse-lookup of every
+        // mod's ScriptExtender/Config.json.
+        size_t pak_size = 0;
+        char *pak_content = io_load_from_pak(path, &pak_size);
+        if (pak_content) {
+            lua_pushlstring(L, pak_content, pak_size);
+            free(pak_content);
+            return 1;
+        }
         lua_pushnil(L);
         lua_pushstring(L, "File not found");
         return 2;
@@ -117,13 +211,25 @@ int lua_ext_io_savefile(lua_State *L) {
     const char *content = luaL_checkstring(L, 2);
     LOG_LUA_INFO("Ext.IO.SaveFile('%s')", path);
 
-    FILE *f = fopen(path, "w");
+    // Windows BG3SE writes to <UserProfile>/Script Extender/<path> (PathRootType
+    // ::UserProfile) and mkdir -p's the parents. Mirror that so MCM's settings /
+    // profiles / open_on_start migration actually persist.
+    char full[MAX_PATH_LEN];
+    if (path[0] == '/') {
+        snprintf(full, sizeof(full), "%s", path);  // absolute: honor as-is
+    } else {
+        snprintf(full, sizeof(full), "%s/%s", io_se_data_base(), path);
+    }
+    io_mkdir_parents(full);
+
+    FILE *f = fopen(full, "w");
     if (!f) {
+        LOG_LUA_INFO("Ext.IO.SaveFile: could not open '%s' for writing", full);
         lua_pushboolean(L, 0);
         return 1;
     }
 
-    fputs(content, f);
+    fwrite(content, 1, strlen(content), f);
     fclose(f);
 
     lua_pushboolean(L, 1);

--- a/src/lua/lua_ext.c
+++ b/src/lua/lua_ext.c
@@ -157,14 +157,35 @@ static char *io_load_from_pak(const char *path, size_t *out_size) {
     return content;  // already NUL-terminated by pak_read_file
 }
 
+// Reject paths that would escape the Script Extender data dir: absolute
+// paths and any ".." component. Windows BG3SE confines Ext.IO writes to the
+// UserProfile Script Extender root the same way.
+static int io_path_is_contained(const char *path) {
+    if (!path || !path[0] || path[0] == '/') return 0;
+    const char *p = path;
+    while (*p) {
+        if (p[0] == '.' && p[1] == '.' &&
+            (p[2] == '/' || p[2] == '\0') &&
+            (p == path || p[-1] == '/')) {
+            return 0;
+        }
+        p++;
+    }
+    return 1;
+}
+
 int lua_ext_io_loadfile(lua_State *L) {
     const char *path = luaL_checkstring(L, 1);
     LOG_LUA_INFO("Ext.IO.LoadFile('%s')", path);
 
-    FILE *f = fopen(path, "r");
-    if (!f && path[0] != '/') {
-        // Relative VFS path: try the Script Extender data dir (user-saved data
-        // like MCM's settings.json lives here — see io_se_data_base).
+    // Relative paths resolve against the Script Extender data dir (user-saved
+    // data like MCM's settings.json lives here — see io_se_data_base), never
+    // the process CWD, and may not traverse out of it. Absolute paths are
+    // honored read-only for developer tooling.
+    FILE *f = NULL;
+    if (path[0] == '/') {
+        f = fopen(path, "r");
+    } else if (io_path_is_contained(path)) {
         char se_path[MAX_PATH_LEN];
         snprintf(se_path, sizeof(se_path), "%s/%s", io_se_data_base(), path);
         f = fopen(se_path, "r");
@@ -214,12 +235,13 @@ int lua_ext_io_savefile(lua_State *L) {
     // Windows BG3SE writes to <UserProfile>/Script Extender/<path> (PathRootType
     // ::UserProfile) and mkdir -p's the parents. Mirror that so MCM's settings /
     // profiles / open_on_start migration actually persist.
-    char full[MAX_PATH_LEN];
-    if (path[0] == '/') {
-        snprintf(full, sizeof(full), "%s", path);  // absolute: honor as-is
-    } else {
-        snprintf(full, sizeof(full), "%s/%s", io_se_data_base(), path);
+    if (!io_path_is_contained(path)) {
+        LOG_LUA_INFO("Ext.IO.SaveFile: rejecting path outside SE data dir: '%s'", path);
+        lua_pushboolean(L, 0);
+        return 1;
     }
+    char full[MAX_PATH_LEN];
+    snprintf(full, sizeof(full), "%s/%s", io_se_data_base(), path);
     io_mkdir_parents(full);
 
     FILE *f = fopen(full, "w");

--- a/src/lua/lua_json.c
+++ b/src/lua/lua_json.c
@@ -164,7 +164,52 @@ const char *json_parse_value(lua_State *L, const char *json) {
 // Stringify Functions
 // ============================================================================
 
-static void json_stringify_table(lua_State *L, int index, luaL_Buffer *b) {
+// A plain growable byte buffer. The stringifier builds into this instead of a
+// luaL_Buffer: luaL_Buffer keeps a box userdata on the Lua stack once it grows,
+// and interleaving arbitrary stack pushes/pops (as table iteration requires) with
+// buffer appends corrupts it (SIGSEGV in luaL_prepbuffsize). Building into a
+// malloc'd buffer sidesteps that entirely; the result is copied into the caller's
+// luaL_Buffer in a single, safe append at the top level.
+typedef struct { char *data; size_t len; size_t cap; int oom; } JsonBuf;
+
+// Cap recursion so a cyclic/self-referential table (possible now that mod tables
+// carry an { __index = _G } metatable) fails gracefully instead of overflowing.
+#define JSON_MAX_DEPTH 200
+
+static void jb_init(JsonBuf *jb) {
+    jb->cap = 256; jb->len = 0; jb->oom = 0;
+    jb->data = (char *)malloc(jb->cap);
+    if (!jb->data) jb->oom = 1; else jb->data[0] = '\0';
+}
+static void jb_free(JsonBuf *jb) { free(jb->data); jb->data = NULL; }
+static void jb_reserve(JsonBuf *jb, size_t extra) {
+    if (jb->oom) return;
+    if (jb->len + extra + 1 <= jb->cap) return;
+    size_t nc = jb->cap ? jb->cap : 256;
+    while (nc < jb->len + extra + 1) nc *= 2;
+    char *nd = (char *)realloc(jb->data, nc);
+    if (!nd) { jb->oom = 1; return; }
+    jb->data = nd; jb->cap = nc;
+}
+static void jb_addlstring(JsonBuf *jb, const char *s, size_t n) {
+    if (jb->oom || !s || n == 0) return;
+    jb_reserve(jb, n);
+    if (jb->oom) return;
+    memcpy(jb->data + jb->len, s, n);
+    jb->len += n; jb->data[jb->len] = '\0';
+}
+static void jb_addstring(JsonBuf *jb, const char *s) { if (s) jb_addlstring(jb, s, strlen(s)); }
+static void jb_addchar(JsonBuf *jb, char c) {
+    jb_reserve(jb, 1);
+    if (jb->oom) return;
+    jb->data[jb->len++] = c; jb->data[jb->len] = '\0';
+}
+
+static void json_sb_value(lua_State *L, int index, JsonBuf *jb, int depth);
+
+static void json_sb_table(lua_State *L, int index, JsonBuf *jb, int depth) {
+    if (depth > JSON_MAX_DEPTH) { jb_addstring(jb, "null"); return; }
+
     // Check if it's an array (sequential integer keys starting from 1)
     int is_array = 1;
     int max_index = 0;
@@ -179,75 +224,89 @@ static void json_stringify_table(lua_State *L, int index, luaL_Buffer *b) {
     }
 
     if (is_array && max_index > 0) {
-        luaL_addchar(b, '[');
+        jb_addchar(jb, '[');
         for (int i = 1; i <= max_index; i++) {
-            if (i > 1) luaL_addchar(b, ',');
+            if (i > 1) jb_addchar(jb, ',');
             lua_rawgeti(L, index, i);
-            json_stringify_value(L, lua_gettop(L), b);
+            json_sb_value(L, lua_gettop(L), jb, depth + 1);
             lua_pop(L, 1);
         }
-        luaL_addchar(b, ']');
+        jb_addchar(jb, ']');
     } else {
-        luaL_addchar(b, '{');
+        jb_addchar(jb, '{');
         int first = 1;
         lua_pushnil(L);
         while (lua_next(L, index) != 0) {
-            if (!first) luaL_addchar(b, ',');
+            if (!first) jb_addchar(jb, ',');
             first = 0;
 
-            // Key
-            luaL_addchar(b, '"');
+            // Key (guard against lua_tostring returning NULL for non-string,
+            // non-number keys, which would crash the buffer append).
+            jb_addchar(jb, '"');
             if (lua_type(L, -2) == LUA_TSTRING) {
-                luaL_addstring(b, lua_tostring(L, -2));
+                jb_addstring(jb, lua_tostring(L, -2));
             } else {
                 lua_pushvalue(L, -2);
-                luaL_addstring(b, lua_tostring(L, -1));
+                const char *ks = lua_tostring(L, -1);
+                jb_addstring(jb, ks ? ks : "?");
                 lua_pop(L, 1);
             }
-            luaL_addchar(b, '"');
-            luaL_addchar(b, ':');
+            jb_addchar(jb, '"');
+            jb_addchar(jb, ':');
 
             // Value
-            json_stringify_value(L, lua_gettop(L), b);
+            json_sb_value(L, lua_gettop(L), jb, depth + 1);
             lua_pop(L, 1);
         }
-        luaL_addchar(b, '}');
+        jb_addchar(jb, '}');
     }
 }
 
-void json_stringify_value(lua_State *L, int index, luaL_Buffer *b) {
+static void json_sb_value(lua_State *L, int index, JsonBuf *jb, int depth) {
     int t = lua_type(L, index);
     switch (t) {
         case LUA_TSTRING: {
             const char *s = lua_tostring(L, index);
-            luaL_addchar(b, '"');
-            while (*s) {
-                if (*s == '"' || *s == '\\') {
-                    luaL_addchar(b, '\\');
-                }
-                luaL_addchar(b, *s);
-                s++;
+            jb_addchar(jb, '"');
+            for (; s && *s; s++) {
+                if (*s == '"' || *s == '\\') jb_addchar(jb, '\\');
+                jb_addchar(jb, *s);
             }
-            luaL_addchar(b, '"');
+            jb_addchar(jb, '"');
             break;
         }
         case LUA_TNUMBER: {
             char buf[64];
             snprintf(buf, sizeof(buf), "%g", lua_tonumber(L, index));
-            luaL_addstring(b, buf);
+            jb_addstring(jb, buf);
             break;
         }
         case LUA_TBOOLEAN:
-            luaL_addstring(b, lua_toboolean(L, index) ? "true" : "false");
+            jb_addstring(jb, lua_toboolean(L, index) ? "true" : "false");
             break;
         case LUA_TTABLE:
-            json_stringify_table(L, index, b);
+            json_sb_table(L, index, jb, depth);
             break;
         case LUA_TNIL:
         default:
-            luaL_addstring(b, "null");
+            jb_addstring(jb, "null");
             break;
     }
+}
+
+// Public entry point kept for existing callers (user_variables, persistentvars,
+// main). Builds into a private malloc buffer, then appends the whole result to
+// the caller's luaL_Buffer in one safe operation.
+void json_stringify_value(lua_State *L, int index, luaL_Buffer *b) {
+    JsonBuf jb;
+    jb_init(&jb);
+    json_sb_value(L, index, &jb, 0);
+    if (!jb.oom && jb.data && jb.len > 0) {
+        luaL_addlstring(b, jb.data, jb.len);
+    } else if (jb.oom) {
+        luaL_addstring(b, "null");
+    }
+    jb_free(&jb);
 }
 
 // ============================================================================

--- a/src/lua/lua_mod.c
+++ b/src/lua/lua_mod.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 // ============================================================================
 // Static State: UUID to Name Mapping
@@ -25,6 +26,8 @@
 typedef struct {
     char uuid[UUID_LEN];
     char name[256];
+    char folder[256];       // meta Folder (== pak internal dir); Directory for Info
+    char version64[32];     // packed int64 version string, decoded into Info.ModVersion
 } ModUuidEntry;
 
 static ModUuidEntry g_mod_uuids[MAX_MOD_UUIDS];
@@ -126,12 +129,38 @@ static void load_mod_uuids(void) {
             }
         }
 
+        // Extract Folder (pak internal directory) and Version64
+        const char *folder_marker = "attribute id=\"Folder\" type=\"LSString\" value=\"";
+        const char *folder_start = strstr(node_start, folder_marker);
+        char folder[256] = "";
+        if (folder_start && folder_start < node_end) {
+            folder_start += strlen(folder_marker);
+            const char *fe = strchr(folder_start, '"');
+            if (fe && fe < node_end) {
+                size_t len = fe - folder_start;
+                if (len < sizeof(folder)) { strncpy(folder, folder_start, len); folder[len] = '\0'; }
+            }
+        }
+
+        const char *ver_marker = "attribute id=\"Version64\" type=\"int64\" value=\"";
+        const char *ver_start = strstr(node_start, ver_marker);
+        char version64[32] = "";
+        if (ver_start && ver_start < node_end) {
+            ver_start += strlen(ver_marker);
+            const char *ve = strchr(ver_start, '"');
+            if (ve && ve < node_end) {
+                size_t len = ve - ver_start;
+                if (len < sizeof(version64)) { strncpy(version64, ver_start, len); version64[len] = '\0'; }
+            }
+        }
+
         // Store if both found
         if (uuid[0] && name[0] && g_mod_uuid_count < MAX_MOD_UUIDS) {
-            strncpy(g_mod_uuids[g_mod_uuid_count].uuid, uuid, UUID_LEN - 1);
-            g_mod_uuids[g_mod_uuid_count].uuid[UUID_LEN - 1] = '\0';  // Ensure null termination
-            strncpy(g_mod_uuids[g_mod_uuid_count].name, name, 255);
-            g_mod_uuids[g_mod_uuid_count].name[255] = '\0';  // Ensure null termination
+            ModUuidEntry *e = &g_mod_uuids[g_mod_uuid_count];
+            strncpy(e->uuid, uuid, UUID_LEN - 1);   e->uuid[UUID_LEN - 1] = '\0';
+            strncpy(e->name, name, 255);            e->name[255] = '\0';
+            strncpy(e->folder, folder, 255);        e->folder[255] = '\0';
+            strncpy(e->version64, version64, 31);   e->version64[31] = '\0';
             g_mod_uuid_count++;
         }
 
@@ -213,6 +242,69 @@ static int lua_mod_get_load_order(lua_State *L) {
 }
 
 /**
+ * Push a mod object matching the real BG3SE shape: a top-level table plus a
+ * nested `Info` (ModuleInfo) table. SE libraries (CommunityLibrary, MCM,
+ * CompatibilityFramework) read mod.Info.ModVersion / .Directory / .ModuleUUID;
+ * a missing Info table aborted their bootstraps.
+ */
+static void push_mod_table(lua_State *L, const ModUuidEntry *e) {
+    const char *dir = e->folder[0] ? e->folder : e->name;
+
+    lua_newtable(L);  // mod
+
+    lua_pushstring(L, e->uuid);  lua_setfield(L, -2, "UUID");
+    lua_pushstring(L, e->name);  lua_setfield(L, -2, "Name");
+    lua_pushstring(L, dir);      lua_setfield(L, -2, "Directory");
+
+    int se_count = mod_get_se_count();
+    bool is_se = false;
+    for (int j = 0; j < se_count; j++) {
+        const char *sn = mod_get_se_name(j);
+        if (sn && (strcasecmp(sn, e->name) == 0 ||
+                   (e->folder[0] && strcasecmp(sn, e->folder) == 0))) {
+            is_se = true;
+            break;
+        }
+    }
+    lua_pushboolean(L, is_se);  lua_setfield(L, -2, "HasScriptExtender");
+
+    // Info (ModuleInfo) sub-table — what SE libraries actually read.
+    lua_newtable(L);  // Info
+    lua_pushstring(L, e->name);  lua_setfield(L, -2, "Name");
+    lua_pushstring(L, dir);      lua_setfield(L, -2, "Directory");
+    lua_pushstring(L, e->uuid);  lua_setfield(L, -2, "ModuleUUID");
+    lua_pushstring(L, "");       lua_setfield(L, -2, "Author");
+    lua_pushstring(L, "");       lua_setfield(L, -2, "Description");
+
+    // ModVersion, decoded from the packed int64 (Norbyte layout):
+    // Major:7 (>>55) Minor:8 (>>47) Revision:16 (>>31) Build:31 (low).
+    uint64_t v = e->version64[0] ? strtoull(e->version64, NULL, 10) : 0;
+    lua_Integer major = (lua_Integer)((v >> 55) & 0x7f);
+    lua_Integer minor = (lua_Integer)((v >> 47) & 0xff);
+    lua_Integer revision = (lua_Integer)((v >> 31) & 0xffff);
+    lua_Integer build = (lua_Integer)(v & 0x7fffffff);
+    lua_newtable(L);  // ModVersion
+    // Array form ModVersion[1..4] — this is what mods (MCM, CommunityLibrary)
+    // actually read (e.g. string.format("%d.%d.%d.%d", ModVersion[1], ...)).
+    // A missing [1] made string.format throw and aborted MCM's CreateModMenu,
+    // which is why UIReady never fired (window auto-opened, content stayed empty).
+    lua_pushinteger(L, major);    lua_rawseti(L, -2, 1);
+    lua_pushinteger(L, minor);    lua_rawseti(L, -2, 2);
+    lua_pushinteger(L, revision); lua_rawseti(L, -2, 3);
+    lua_pushinteger(L, build);    lua_rawseti(L, -2, 4);
+    // Named fields too, for consumers that use them.
+    lua_pushinteger(L, major);    lua_setfield(L, -2, "Major");
+    lua_pushinteger(L, minor);    lua_setfield(L, -2, "Minor");
+    lua_pushinteger(L, revision); lua_setfield(L, -2, "Revision");
+    lua_pushinteger(L, build);    lua_setfield(L, -2, "Build");
+    lua_setfield(L, -2, "ModVersion");
+
+    lua_newtable(L);  lua_setfield(L, -2, "Dependencies");
+
+    lua_setfield(L, -2, "Info");  // mod.Info = Info
+}
+
+/**
  * Ext.Mod.GetMod(modGuid) -> table|nil
  *
  * Get mod information by UUID.
@@ -224,29 +316,7 @@ static int lua_mod_get_mod(lua_State *L) {
 
     for (int i = 0; i < g_mod_uuid_count; i++) {
         if (strcasecmp(g_mod_uuids[i].uuid, uuid) == 0) {
-            lua_newtable(L);
-
-            lua_pushstring(L, g_mod_uuids[i].uuid);
-            lua_setfield(L, -2, "UUID");
-
-            lua_pushstring(L, g_mod_uuids[i].name);
-            lua_setfield(L, -2, "Name");
-
-            lua_pushstring(L, g_mod_uuids[i].name);
-            lua_setfield(L, -2, "Directory");
-
-            // Check if it's an SE mod
-            int se_count = mod_get_se_count();
-            bool is_se = false;
-            for (int j = 0; j < se_count; j++) {
-                if (strcasecmp(mod_get_se_name(j), g_mod_uuids[i].name) == 0) {
-                    is_se = true;
-                    break;
-                }
-            }
-            lua_pushboolean(L, is_se);
-            lua_setfield(L, -2, "HasScriptExtender");
-
+            push_mod_table(L, &g_mod_uuids[i]);
             return 1;
         }
     }

--- a/src/lua/lua_osiris.c
+++ b/src/lua/lua_osiris.c
@@ -76,7 +76,10 @@ int lua_ext_osiris_registerlistener(lua_State *L) {
     LOG_LUA_DEBUG("Registered Osiris listener: %s (arity=%d, timing=%s)",
                 event, arity, timing);
 
-    return 0;
+    // Return the 1-based listener index as a subscription handle so callers
+    // can hold on to their registration (tier-2 Parity.Osi.ListenerBeforeAfter).
+    lua_pushinteger(L, osiris_listener_count);
+    return 1;
 }
 
 // ============================================================================

--- a/src/mod/mod_loader.c
+++ b/src/mod/mod_loader.c
@@ -376,11 +376,13 @@ void mod_detect_enabled(void) {
     int mod_count = 0;
     char *ptr = content;
     // Key on the mod's Folder, NOT its Name. ScriptExtender files inside a pak
-    // live at Mods/<Folder>/ScriptExtender/..., and the Folder frequently differs
-    // from the display Name (e.g. "Mod Configuration Menu" -> folder "BG3MCM",
-    // "Sit This One Out 2" -> folder "Sit This One Out"). Parsing Name here caused
-    // those mods' bootstraps to never load. Folder values are also unescaped
-    // identifiers, avoiding &apos;-style HTML entities present in Names.
+    // live at Mods/<Folder>/ScriptExtender/..., and the Folder can differ from
+    // the display Name (e.g. "Sit This One Out 2" -> folder "Sit This One
+    // Out"; MCM's modsettings Folder is "Mod Configuration Menu" and only the
+    // PAK-stem/se_mod_dirs fallback resolves its real "BG3MCM" directory).
+    // Parsing Name here caused such mods' bootstraps to never load. Folder
+    // values are also unescaped identifiers, avoiding &apos;-style HTML
+    // entities present in Names.
     const char *name_marker = "attribute id=\"Folder\" type=\"LSString\" value=\"";
     size_t marker_len = strlen(name_marker);
 

--- a/src/mod/mod_loader.c
+++ b/src/mod/mod_loader.c
@@ -23,14 +23,16 @@
 
 // Detected mods from modsettings.lsx
 static char detected_mods[MAX_MODS][MAX_MOD_NAME_LEN];
+static char detected_uuids[MAX_MODS][64];  // parallel to detected_mods (mod UUIDs)
 static int detected_mod_count = 0;
 
 // Detected SE mods (mods with ScriptExtender/Config.json containing "Lua").
-// se_mods holds the modsettings.lsx display name; se_mod_dirs holds the
+// se_mods holds the modsettings.lsx Folder name; se_mod_dirs holds the
 // resolved internal PAK directory name, which is what every Mods/<dir>/...
-// path must be built from — the two frequently differ (#87, #81).
+// path must be built from (#87, #81). se_mod_uuids parallels se_mods.
 static char se_mods[MAX_MODS][MAX_MOD_NAME_LEN];
 static char se_mod_dirs[MAX_MODS][MAX_MOD_NAME_LEN];
+static char se_mod_uuids[MAX_MODS][64];
 static int se_mod_count = 0;
 
 // Current mod context (for Ext.Require)
@@ -276,6 +278,12 @@ int mod_find_pak(const char *mod_name, char *pak_path_out, size_t pak_path_size)
     return 0;
 }
 
+static mod_chunk_env_hook_t g_chunk_env_hook = NULL;
+
+void mod_loader_set_chunk_env_hook(mod_chunk_env_hook_t hook) {
+    g_chunk_env_hook = hook;
+}
+
 int mod_load_lua_from_pak(lua_State *L, const char *pak_path, const char *lua_path) {
     PakFile *pak = pak_open(pak_path);
     if (!pak) return 0;
@@ -292,16 +300,28 @@ int mod_load_lua_from_pak(lua_State *L, const char *pak_path, const char *lua_pa
 
     if (!content) return 0;
 
-    // Execute the Lua code
-    if (luaL_dostring(L, content) != LUA_OK) {
+    // Load the chunk (do NOT execute yet): we must install the per-mod _ENV on the
+    // loaded function before running it, so mods like MCM whose API lives on their
+    // ModTable (Mods.<ModTable>) can reference it as a bare global.
+    if (luaL_loadbuffer(L, content, size, lua_path) != LUA_OK) {
         const char *error = lua_tostring(L, -1);
-        LOG_LUA_ERROR("PAK load error (%s): %s", lua_path, error);
+        LOG_LUA_ERROR("PAK compile error (%s): %s", lua_path, error);
         lua_pop(L, 1);
         free(content);
         return 0;
     }
-
     free(content);
+
+    // Install per-mod _ENV on the freshly loaded chunk (no-op if none is active).
+    if (g_chunk_env_hook) g_chunk_env_hook(L);
+
+    if (lua_pcall(L, 0, LUA_MULTRET, 0) != LUA_OK) {
+        const char *error = lua_tostring(L, -1);
+        LOG_LUA_ERROR("PAK load error (%s): %s", lua_path, error);
+        lua_pop(L, 1);
+        return 0;
+    }
+
     LOG_LUA_INFO("Loaded from PAK: %s", lua_path);
     return 1;
 }
@@ -355,7 +375,13 @@ void mod_detect_enabled(void) {
 
     int mod_count = 0;
     char *ptr = content;
-    const char *name_marker = "attribute id=\"Name\" type=\"LSString\" value=\"";
+    // Key on the mod's Folder, NOT its Name. ScriptExtender files inside a pak
+    // live at Mods/<Folder>/ScriptExtender/..., and the Folder frequently differs
+    // from the display Name (e.g. "Mod Configuration Menu" -> folder "BG3MCM",
+    // "Sit This One Out 2" -> folder "Sit This One Out"). Parsing Name here caused
+    // those mods' bootstraps to never load. Folder values are also unescaped
+    // identifiers, avoiding &apos;-style HTML entities present in Names.
+    const char *name_marker = "attribute id=\"Folder\" type=\"LSString\" value=\"";
     size_t marker_len = strlen(name_marker);
 
     while ((ptr = strstr(ptr, name_marker)) != NULL) {
@@ -373,6 +399,26 @@ void mod_detect_enabled(void) {
                 // Store in detected mods array
                 strncpy(detected_mods[detected_mod_count], mod_name, MAX_MOD_NAME_LEN - 1);
                 detected_mods[detected_mod_count][MAX_MOD_NAME_LEN - 1] = '\0';
+
+                // Capture this ModuleShortDesc's UUID (appears after Folder, before
+                // the next node) so we can set the ModuleUUID Lua global per mod.
+                detected_uuids[detected_mod_count][0] = '\0';
+                {
+                    const char *uuid_marker = "id=\"UUID\" type=\"guid\" value=\"";
+                    char *next_folder = strstr(end, name_marker);
+                    char *uuid_pos = strstr(end, uuid_marker);
+                    if (uuid_pos && (!next_folder || uuid_pos < next_folder)) {
+                        uuid_pos += strlen(uuid_marker);
+                        char *uend = strchr(uuid_pos, '"');
+                        if (uend) {
+                            size_t ulen = (size_t)(uend - uuid_pos);
+                            if (ulen < sizeof(detected_uuids[0])) {
+                                strncpy(detected_uuids[detected_mod_count], uuid_pos, ulen);
+                                detected_uuids[detected_mod_count][ulen] = '\0';
+                            }
+                        }
+                    }
+                }
                 detected_mod_count++;
 
                 mod_count++;
@@ -404,6 +450,8 @@ void mod_detect_enabled(void) {
                 se_mods[se_mod_count][MAX_MOD_NAME_LEN - 1] = '\0';
                 strncpy(se_mod_dirs[se_mod_count], mod_dir, MAX_MOD_NAME_LEN - 1);
                 se_mod_dirs[se_mod_count][MAX_MOD_NAME_LEN - 1] = '\0';
+                strncpy(se_mod_uuids[se_mod_count], detected_uuids[i], sizeof(se_mod_uuids[0]) - 1);
+                se_mod_uuids[se_mod_count][sizeof(se_mod_uuids[0]) - 1] = '\0';
                 se_mod_count++;
                 LOG_MOD_INFO("  [SE] %s", detected_mods[i]);
             }
@@ -456,6 +504,7 @@ void mod_detect_enabled(void) {
                         se_mods[se_mod_count][MAX_MOD_NAME_LEN - 1] = '\0';
                         strncpy(se_mod_dirs[se_mod_count], entry->d_name, MAX_MOD_NAME_LEN - 1);
                         se_mod_dirs[se_mod_count][MAX_MOD_NAME_LEN - 1] = '\0';
+                        se_mod_uuids[se_mod_count][0] = '\0';  // UUID unknown for folder-scan mods
                         se_mod_count++;
                         LOG_MOD_INFO("  [SE] %s (from Mods folder)", entry->d_name);
                     }
@@ -516,6 +565,7 @@ void mod_detect_enabled(void) {
                     se_mods[se_mod_count][MAX_MOD_NAME_LEN - 1] = '\0';
                     strncpy(se_mod_dirs[se_mod_count], se_dir, MAX_MOD_NAME_LEN - 1);
                     se_mod_dirs[se_mod_count][MAX_MOD_NAME_LEN - 1] = '\0';
+                    se_mod_uuids[se_mod_count][0] = '\0';  // UUID unknown for PAK-scan mods
                     se_mod_count++;
                     LOG_MOD_INFO("  [SE] %s (from PAK %s)", se_dir, entry->d_name);
                 }
@@ -543,6 +593,11 @@ int mod_get_se_count(void) {
 const char *mod_get_se_name(int index) {
     if (index < 0 || index >= se_mod_count) return NULL;
     return se_mods[index];
+}
+
+const char *mod_get_se_uuid(int index) {
+    if (index < 0 || index >= se_mod_count) return NULL;
+    return se_mod_uuids[index];
 }
 
 const char *mod_get_se_dir(int index) {

--- a/src/mod/mod_loader.h
+++ b/src/mod/mod_loader.h
@@ -63,6 +63,19 @@ const char *mod_get_se_name(int index);
  */
 const char *mod_get_se_dir(int index);
 
+/**
+ * Get the UUID of a detected SE mod by index (empty string if unknown).
+ */
+const char *mod_get_se_uuid(int index);
+
+/**
+ * Hook invoked after a mod chunk is loaded (function on top of the Lua stack)
+ * but before it is executed, so the loader can install the per-mod _ENV
+ * (Mods.<ModTable>) on the chunk. See main.c mod_env_apply().
+ */
+typedef void (*mod_chunk_env_hook_t)(lua_State *L);
+void mod_loader_set_chunk_env_hook(mod_chunk_env_hook_t hook);
+
 // ============================================================================
 // PAK File Helpers
 // ============================================================================

--- a/src/network/net_hooks.c
+++ b/src/network/net_hooks.c
@@ -23,6 +23,7 @@
 #include "network_backend.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/offset_table.h"
 #include "../game/game_state.h"        // game_state_get_current()
 #include "../entity/entity_system.h"   // entity_get_binary_base(), entity_get_eoc_server()
 #include <dobby.h>
@@ -96,7 +97,11 @@ static bool safe_read_u64(const void *base, uintptr_t offset, uint64_t *out) {
 static uintptr_t get_runtime_addr(uintptr_t ghidra_addr) {
     void *base = entity_get_binary_base();
     if (!base) return 0;
-    return ghidra_addr - GHIDRA_BASE_ADDRESS + (uintptr_t)base;
+    // Remap the hardcoded 6995620 address to the running version (0 = no verified
+    // address -> caller skips the hook rather than hooking a stale function).
+    uint64_t remapped = offset_table_remap_fn(ghidra_addr);
+    if (!remapped) return 0;
+    return remapped - GHIDRA_BASE_ADDRESS + (uintptr_t)base;
 }
 
 // ============================================================================

--- a/src/osiris/osiris_functions.c
+++ b/src/osiris/osiris_functions.c
@@ -498,21 +498,41 @@ void osi_func_enumerate(void) {
     // Osiris function IDs are split into two ranges:
     // 1. Regular functions: 0 to ~64K (low IDs)
     // 2. Registered functions: 0x80000000 + offset (high bit set)
+    //
+    // Caps are kept below MAX_CACHED_FUNCTIONS (4096) to avoid overflow.
+    // Databases (DB_Players, DB_PartyMembers, ...) live among the regular
+    // functions but at higher IDs; the previous found_count<1000 low-range cap
+    // stopped the scan before reaching them, so Osi.DB_*:Get() always returned
+    // empty. Widened to 20000/found_count<4000 (low) and 50000 (high) so DB
+    // nodes are captured. This function is idempotent — osi_func_cache() dedups
+    // by ID, and already-cached IDs are skipped below — so it is safe to re-run
+    // after the story loads (see fake_Event re-enumeration on SavegameLoaded).
+    #define ENUM_CAP 4000
 
-    // Probe low range (regular functions) - usually 0-10000
-    for (uint32_t id = 1; id < 10000 && found_count < 1000; id++) {
+    // Probe low range (regular functions incl. databases)
+    for (uint32_t id = 1; id < 20000 && found_count < ENUM_CAP; id++) {
+        if (osi_func_get_name(id) != NULL) {  // already cached — skip expensive probe
+            found_count++;
+            continue;
+        }
         if (osi_func_cache_by_id(id)) {
             found_count++;
         }
     }
 
-    // Probe high range (registered functions) - 0x80000000 + 0 to ~30000
-    for (uint32_t offset = 0; offset < 30000 && found_count < 2000; offset++) {
+    // Probe high range (registered functions) - 0x80000000 + 0 to ~50000
+    for (uint32_t offset = 0; offset < 50000 && found_count < ENUM_CAP; offset++) {
         uint32_t id = 0x80000000 | offset;
+        if (osi_func_get_name(id) != NULL) {  // already cached — skip expensive probe
+            found_count++;
+            continue;
+        }
         if (osi_func_cache_by_id(id)) {
             found_count++;
         }
     }
+
+    #undef ENUM_CAP
 
     LOG_OSIRIS_DEBUG("Enumeration complete: %d functions cached", found_count);
 
@@ -530,6 +550,190 @@ void osi_func_enumerate(void) {
             LOG_OSIRIS_DEBUG("  %s -> 0x%08x", key_funcs[i], fid);
         }
     }
+}
+
+/* Extract name/arity/type/handle from a resolved OsiFunctionData* and cache it
+ * under funcId. Self-contained (mirrors the extraction in osi_func_cache_by_id)
+ * so the name-index walk can cache defs it already holds without re-probing by
+ * id. Returns 1 if a name was extracted and cached. */
+static int osi_func_cache_def(void *funcDef, uint32_t funcId) {
+    if (!funcDef) return 0;
+
+    const char *name = extract_func_name_from_def(funcDef);
+    if (!name || !name[0]) return 0;
+
+    /* Arity: funcDef+0x18 → Signature → +0x10 ParamList → +0x10 Size (in+out). */
+    uint8_t arity = 0;
+    void *sigPtr = NULL;
+    if (safe_memory_read_pointer((mach_vm_address_t)funcDef + OSIFUNCDEF_SIGNATURE_OFFSET, &sigPtr) && sigPtr) {
+        void *paramListPtr = NULL;
+        if (safe_memory_read_pointer((mach_vm_address_t)sigPtr + FUNCSIG_PARAMS_OFFSET, &paramListPtr) && paramListPtr) {
+            uint32_t paramSize = 0;
+            if (safe_memory_read_u32((mach_vm_address_t)paramListPtr + PARAMLIST_SIZE_OFFSET, &paramSize)) {
+                arity = (paramSize <= 20) ? (uint8_t)paramSize : 0;
+            }
+        }
+    }
+
+    /* Type + Key[4] at funcDef+0x28 (same layout the id-based path uses). */
+    uint8_t type = osi_func_guess_type(name);
+    uint32_t keys[4] = {0};
+    uint32_t handle = funcId;
+    if (safe_memory_read((mach_vm_address_t)funcDef + 0x28, keys, sizeof(keys))) {
+        if (keys[0] >= OSI_FUNC_EVENT && keys[0] <= OSI_FUNC_USERQUERY) {
+            type = (uint8_t)keys[0];
+            handle = osi_encode_handle(keys[0], keys[1], keys[2], keys[3]);
+        }
+    }
+
+    osi_func_cache(name, funcId, arity, type);
+    if (handle != 0) {
+        osi_func_cache_set_handle(funcId, handle);
+    }
+    return 1;
+}
+
+// ============================================================================
+// Database registry
+// ============================================================================
+// Osiris databases (DB_*) have OsiFunctionId==0 — they cannot be keyed in the
+// id-based function cache. Instead we register name -> COsiFunctionData* so the
+// Facts reader (osi_db_read_facts in main.c) can resolve them.
+
+#define MAX_DATABASES 32768
+typedef struct { char name[96]; void *def; } DbRegEntry;
+static DbRegEntry g_dbReg[MAX_DATABASES];
+static int g_dbRegCount = 0;
+
+int osi_db_register(const char *name, void *def) {
+    if (!name || !name[0] || !def) return 0;
+    for (int i = 0; i < g_dbRegCount; i++) {
+        if (strcmp(g_dbReg[i].name, name) == 0) {
+            g_dbReg[i].def = def;  /* refresh on re-enumeration */
+            return 0;
+        }
+    }
+    if (g_dbRegCount >= MAX_DATABASES) return 0;
+    strncpy(g_dbReg[g_dbRegCount].name, name, sizeof(g_dbReg[0].name) - 1);
+    g_dbReg[g_dbRegCount].name[sizeof(g_dbReg[0].name) - 1] = '\0';
+    g_dbReg[g_dbRegCount].def = def;
+    g_dbRegCount++;
+    return 1;
+}
+
+void *osi_db_lookup(const char *name) {
+    if (!name) return NULL;
+    for (int i = 0; i < g_dbRegCount; i++) {
+        if (strcmp(g_dbReg[i].name, name) == 0) return g_dbReg[i].def;
+    }
+    return NULL;
+}
+
+int osi_db_count(void) { return g_dbRegCount; }
+
+/* Walk the Osiris name index (CSearchIndex<COsiFunctionData*, COsiString, 1023>)
+ * that lives at the start of COsiFunctionMan and cache every function BY NAME.
+ *
+ * Unlike osi_func_enumerate() — which brute-force probes numeric IDs via
+ * COsiFunctionMan::pFunctionData(uint) and only sees the runtime id-index —
+ * this walks the *name* index, which is the ONLY place Osiris databases
+ * (DB_Players, DB_PartyMembers, DB_Avatars, ...) are registered. Without this,
+ * Osi.DB_*:Get() can never resolve a funcId and always returns empty, breaking
+ * every mod that reads an Osiris database.
+ *
+ * Layout reverse-engineered from COsiFunctionMan::pFunctionData(CKey const&)
+ * (libOsiris arm64 @ 0x29b88):
+ *   manager = *s_ppOsiFunctionMan
+ *   bucket  = manager + (hash % 1023) * 0x18 ; tree root = *(bucket + 0x8)
+ *   node    : left=*(n+0x00), right=*(n+0x08), value(COsiFunctionData*)=*(n+0x38)
+ * All reads go through safe_memory_* so bad pointers fail gracefully; total
+ * node visits are capped to bound worst-case cost against a malformed tree. */
+void osi_func_enumerate_by_name(void) {
+    if (!s_ppOsiFunctionMan) {
+        LOG_OSIRIS_DEBUG("enumerate_by_name: OsiFunctionMan pointer not set");
+        return;
+    }
+    void *manager = NULL;
+    if (!safe_memory_read_pointer((mach_vm_address_t)s_ppOsiFunctionMan, &manager) || !manager) {
+        LOG_OSIRIS_DEBUG("enumerate_by_name: OsiFunctionMan is null");
+        return;
+    }
+
+    LOG_OSIRIS_DEBUG("Starting name-index enumeration (databases included)...");
+
+    #define OSI_NAME_BUCKETS   1023
+    #define OSI_BUCKET_STRIDE  0x18
+    #define OSI_NODE_LEFT      0x00
+    #define OSI_NODE_RIGHT     0x08
+    #define OSI_NODE_VALUE     0x38
+    #define OSI_WALK_STACK     8192
+    #define OSI_MAX_VISITS     200000
+
+    void *stack[OSI_WALK_STACK];
+    int found = 0;
+    int totalVisits = 0;
+
+    for (int b = 0; b < OSI_NAME_BUCKETS; b++) {
+        mach_vm_address_t bucket = (mach_vm_address_t)manager +
+                                   (mach_vm_address_t)b * OSI_BUCKET_STRIDE;
+        void *root = NULL;
+        if (!safe_memory_read_pointer(bucket + 0x8, &root) || !root) {
+            continue;
+        }
+
+        int sp = 0;
+        stack[sp++] = root;
+        while (sp > 0 && totalVisits < OSI_MAX_VISITS) {
+            void *node = stack[--sp];
+            if (!node) continue;
+            totalVisits++;
+
+            void *def = NULL;
+            if (safe_memory_read_pointer((mach_vm_address_t)node + OSI_NODE_VALUE, &def) && def) {
+                uint8_t ftype = 0;
+                safe_memory_read_u8((mach_vm_address_t)def + 0x24, &ftype);  /* Type @ def+0x24 */
+                if (ftype == OSI_FUNC_DATABASE) {
+                    /* Databases have OsiFunctionId==0 (not id-cacheable); register
+                     * name -> def so the Facts reader can resolve them. */
+                    const char *dbName = extract_func_name_from_def(def);
+                    if (osi_db_register(dbName, def)) {
+                        found++;
+                    }
+                } else {
+                    uint32_t osiId = 0;
+                    /* OsiFunctionId at def+0x38 (same field the id path caches under). */
+                    if (safe_memory_read_u32((mach_vm_address_t)def + 0x38, &osiId) && osiId != 0) {
+                        if (osi_func_get_name(osiId) == NULL && osi_func_cache_def(def, osiId)) {
+                            found++;
+                        }
+                    }
+                }
+            }
+
+            /* Push children (NULL-terminated leaves). Bounded by stack size. */
+            if (sp < OSI_WALK_STACK - 2) {
+                void *left = NULL, *right = NULL;
+                if (safe_memory_read_pointer((mach_vm_address_t)node + OSI_NODE_LEFT, &left) && left) {
+                    stack[sp++] = left;
+                }
+                if (safe_memory_read_pointer((mach_vm_address_t)node + OSI_NODE_RIGHT, &right) && right) {
+                    stack[sp++] = right;
+                }
+            }
+        }
+    }
+
+    #undef OSI_NAME_BUCKETS
+    #undef OSI_BUCKET_STRIDE
+    #undef OSI_NODE_LEFT
+    #undef OSI_NODE_RIGHT
+    #undef OSI_NODE_VALUE
+    #undef OSI_WALK_STACK
+    #undef OSI_MAX_VISITS
+
+    LOG_OSIRIS_INFO("Name-index enumeration: %d new entries (%d visits); "
+                    "databases registered=%d, DB_Players %s", found, totalVisits,
+                    osi_db_count(), osi_db_lookup("DB_Players") ? "FOUND" : "missing");
 }
 
 // ============================================================================

--- a/src/osiris/osiris_functions.c
+++ b/src/osiris/osiris_functions.c
@@ -600,10 +600,12 @@ static int osi_func_cache_def(void *funcDef, uint32_t funcId) {
 // id-based function cache. Instead we register name -> COsiFunctionData* so the
 // Facts reader (osi_db_read_facts in main.c) can resolve them.
 
-#define MAX_DATABASES 32768
+#define MAX_DATABASES 8192
 typedef struct { char name[96]; void *def; } DbRegEntry;
 static DbRegEntry g_dbReg[MAX_DATABASES];
 static int g_dbRegCount = 0;
+
+void osi_db_clear(void) { g_dbRegCount = 0; }
 
 int osi_db_register(const char *name, void *def) {
     if (!name || !name[0] || !def) return 0;

--- a/src/osiris/osiris_functions.h
+++ b/src/osiris/osiris_functions.h
@@ -59,6 +59,23 @@ void osi_func_cache_set_known_events(KnownEvent *events);
  */
 void osi_func_enumerate(void);
 
+/**
+ * Walk the Osiris name index (CSearchIndex in COsiFunctionMan) and cache every
+ * function by name — including databases (DB_*), which the id-probe in
+ * osi_func_enumerate() cannot see. Call once the story/save is loaded so
+ * Osi.DB_*:Get() can resolve. Idempotent; read-only.
+ */
+void osi_func_enumerate_by_name(void);
+
+/**
+ * Database registry (databases have OsiFunctionId==0 and cannot be id-cached).
+ * osi_db_register: name -> COsiFunctionData* (returns 1 if newly added).
+ * osi_db_lookup: returns the COsiFunctionData* for a DB name, or NULL.
+ */
+int   osi_db_register(const char *name, void *def);
+void *osi_db_lookup(const char *name);
+int   osi_db_count(void);
+
 // ============================================================================
 // Caching
 // ============================================================================

--- a/src/osiris/osiris_functions.h
+++ b/src/osiris/osiris_functions.h
@@ -75,6 +75,7 @@ void osi_func_enumerate_by_name(void);
 int   osi_db_register(const char *name, void *def);
 void *osi_db_lookup(const char *name);
 int   osi_db_count(void);
+void  osi_db_clear(void);   // wipe registry (defs go stale across save reloads)
 
 // ============================================================================
 // Caching

--- a/src/overlay/overlay.m
+++ b/src/overlay/overlay.m
@@ -678,7 +678,11 @@ static NSColor* colorForLogLevel(const char* text) {
 - (void)flushPendingOutput {
     NSArray *lines;
     @synchronized (self) {
-        lines = self.pendingLines;
+        // This file compiles WITHOUT ARC: the strong-property setter releases
+        // the array when we nil it below, so the raw local must retain first
+        // or it dangles (PAC crash in objc_msgSend at boot log volume,
+        // flushPendingOutput+108, 2026-07-29 .ips).
+        lines = [[self.pendingLines retain] autorelease];
         self.pendingLines = nil;
         self.flushScheduled = NO;
     }

--- a/src/pak/pak_reader.c
+++ b/src/pak/pak_reader.c
@@ -175,12 +175,17 @@ char *pak_read_file(PakFile *pak, int entry_idx, size_t *out_size) {
     char *content = NULL;
 
     if (entry->compression == PAK_COMPRESSION_NONE) {
-        // Uncompressed
-        content = (char *)malloc(entry->uncompressed_size + 1);
+        // Uncompressed: the on-disk bytes ARE the file. For stored entries the
+        // uncompressed_size field is frequently 0 (disk_size is authoritative),
+        // so using uncompressed_size here returned an empty buffer — which made
+        // e.g. Mod Configuration Menu's uncompressed Config.json read as "" and
+        // its whole Script Extender payload fail to load. Use disk_size.
+        size_t n = entry->disk_size;
+        content = (char *)malloc(n + 1);
         if (content) {
-            memcpy(content, disk_data, entry->uncompressed_size);
-            content[entry->uncompressed_size] = '\0';
-            if (out_size) *out_size = entry->uncompressed_size;
+            memcpy(content, disk_data, n);
+            content[n] = '\0';
+            if (out_size) *out_size = n;
         }
     } else if (entry->compression == PAK_COMPRESSION_ZLIB) {
         // zlib

--- a/src/pak/pak_reader.c
+++ b/src/pak/pak_reader.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <zlib.h>
 #include "lz4/lz4.h"
 
@@ -159,6 +160,21 @@ char *pak_read_file(PakFile *pak, int entry_idx, size_t *out_size) {
 
     PakEntry *entry = &pak->entries[entry_idx];
     FILE *f = (FILE *)pak->file;
+
+    // Entry offsets/sizes come straight from the archive: validate against the
+    // real file size before allocating, so a malformed or truncated PAK can't
+    // request a multi-gigabyte buffer or read past EOF. 256 MB comfortably
+    // covers any legitimate single Script Extender payload.
+    const uint64_t PAK_MAX_ENTRY_SIZE = 256ull * 1024 * 1024;
+    struct stat st;
+    if (fstat(fileno(f), &st) != 0) return NULL;
+    uint64_t file_size = (uint64_t)st.st_size;
+    if (entry->disk_size == 0 || entry->disk_size > PAK_MAX_ENTRY_SIZE ||
+        entry->uncompressed_size > PAK_MAX_ENTRY_SIZE ||
+        entry->offset > file_size ||
+        (uint64_t)entry->disk_size > file_size - entry->offset) {
+        return NULL;
+    }
 
     // Seek to file data
     fseek(f, entry->offset, SEEK_SET);

--- a/src/resource/resource_manager.c
+++ b/src/resource/resource_manager.c
@@ -7,6 +7,7 @@
 #include "resource_manager.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/offset_table.h"
 #include "../strings/fixed_string.h"
 #include <string.h>
 #include <strings.h>
@@ -104,8 +105,12 @@ bool resource_manager_init(void *main_binary_base) {
 
     g_resource.main_binary_base = main_binary_base;
 
-    // Calculate runtime address of ResourceManager global pointer
-    g_resource.resource_manager_ptr = (void**)((uintptr_t)main_binary_base + OFFSET_RESOURCEMANAGER_PTR);
+    const VersionOffsets *off = offset_table_get();
+    if (off && off->resource_mgr_ptr) {
+        g_resource.resource_manager_ptr = (void**)offset_table_resolve(off->resource_mgr_ptr);
+    } else {
+        g_resource.resource_manager_ptr = (void**)((uintptr_t)main_binary_base + OFFSET_RESOURCEMANAGER_PTR);
+    }
 
     log_message("[Resource] Resource manager initialized");
     log_message("[Resource]   Base: %p", main_binary_base);
@@ -219,9 +224,15 @@ void* resource_get(ResourceBankType type, uint32_t fixed_string_id) {
         return NULL;
     }
 
-    // Call GetResource function
-    // Function address = base + offset
-    GetResourceFunc get_resource = (GetResourceFunc)((uintptr_t)g_resource.main_binary_base + OFFSET_GETRESOURCE_FUNC);
+    // Resolve GetResource for the running version (remap the hardcoded 6995620
+    // address; 0 = no verified address for this version -> bail instead of
+    // calling a stale function).
+    uint64_t fn_ghidra = offset_table_remap_fn(0x100000000ULL + OFFSET_GETRESOURCE_FUNC);
+    if (!fn_ghidra) {
+        return NULL;
+    }
+    GetResourceFunc get_resource = (GetResourceFunc)((uintptr_t)g_resource.main_binary_base
+                                                     + (fn_ghidra - 0x100000000ULL));
 
     // Note: FixedString is passed as pointer to its hash value
     void* result = get_resource(bank, (uint32_t)type, &fixed_string_id);

--- a/src/staticdata/staticdata_manager.c
+++ b/src/staticdata/staticdata_manager.c
@@ -7,6 +7,8 @@
 #include "staticdata_manager.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/version_detect.h"
+#include "../core/offset_table.h"
 #include "../strings/fixed_string.h"
 #include "../hooks/arm64_hook.h"
 #include <dobby.h>
@@ -16,30 +18,14 @@
 #include <ctype.h>
 
 // ============================================================================
-// Constants and Offsets (Discovered via Ghidra)
+// Constants and Offsets
 // ============================================================================
-
-// Function addresses (relative to base)
-// Re-derived 2026-07-28 via `nm` local symbols for game build 4.1.1.7209685.
-// The previous values (build 4.1.1.6995620) were stale after a game update:
-// OFFSET_GET_CLASS landed mid-function inside gui::HotbarSystem::Update and
-// the resulting Dobby trampoline crashed every session ~30s after save load
-// (docs/bugs/codex-debugger-nohooks-2026-07-28.md). Code offsets MUST be
-// re-verified against nm on every game update; the data sentinels in
-// version_detect do not validate them.
-#define OFFSET_FEAT_GETFEATS          0x01b59814  // eoc::FeatManager::GetFeats() const
-#define OFFSET_GETALLFEATS            0x011ef948  // eoc::character_creation::GetAllFeats
-
-// ImmutableDataHeadmaster m_State pointer address (for TypeContext traversal)
-#define OFFSET_MSTATE_PTR             0x08947ba0  // ls::TypeContext<ls::ImmutableDataHeadmaster>::m_State
-
-// Get<T> function addresses (for real manager capture)
-// These functions return the real manager pointers from ImmutableDataHeadmaster
-#define OFFSET_GET_BACKGROUND         0x0297a068  // Get<eoc::BackgroundManager>
-#define OFFSET_GET_ORIGIN             0x03401c84  // Get<eoc::OriginManager>
-#define OFFSET_GET_CLASS              0x02614874  // Get<eoc::ClassDescriptions>
-#define OFFSET_GET_PROGRESSION        0x0367d764  // Get<eoc::ProgressionManager>
-#define OFFSET_GET_ACTIONRESOURCE     0x011889f4  // Get<eoc::ActionResourceTypes>
+//
+// All address-dependent values (the m_State pointer, the FeatManager::GetFeats
+// and GetAllFeats functions, and the ImmutableDataHeadmaster::Get<T> accessors)
+// are sourced per game version from src/core/offset_table.c. See the
+// VersionOffsets fields: staticdata_mstate_ptr, fn_feat_getfeats,
+// fn_getallfeats, fn_get_background/origin/class/progression/actionresource.
 
 // FeatManager structure offsets
 //
@@ -348,9 +334,14 @@ static int capture_managers_via_typecontext(void) {
         return 0;
     }
 
-    // Safely get pointer to m_State
+    // Safely get pointer to m_State (address from per-version offset table)
+    const VersionOffsets *off = offset_table_get();
+    if (!off || !off->staticdata_mstate_ptr) {
+        log_message("[StaticData] staticdata_mstate_ptr not available for this version");
+        return 0;
+    }
     void* m_state = NULL;
-    mach_vm_address_t ptr_mstate_addr = (mach_vm_address_t)g_staticdata.main_binary_base + OFFSET_MSTATE_PTR;
+    mach_vm_address_t ptr_mstate_addr = (mach_vm_address_t)offset_table_resolve(off->staticdata_mstate_ptr);
     if (!safe_memory_read_pointer(ptr_mstate_addr, &m_state)) {
         log_message("[StaticData] Could not read m_State pointer at %p", (void*)ptr_mstate_addr);
         return 0;
@@ -440,9 +431,13 @@ static void* find_manager_via_typecontext(const char* type_name) {
         return NULL;
     }
 
-    // Get pointer to m_State
-    void** ptr_mstate = (void**)((uint8_t*)g_staticdata.main_binary_base + OFFSET_MSTATE_PTR);
-    void* m_state = *ptr_mstate;
+    // Get pointer to m_State (address from per-version offset table)
+    const VersionOffsets *off = offset_table_get();
+    if (!off || !off->staticdata_mstate_ptr) {
+        return NULL;
+    }
+    void** ptr_mstate = (void**)offset_table_resolve(off->staticdata_mstate_ptr);
+    void* m_state = ptr_mstate ? *ptr_mstate : NULL;
     if (!m_state) {
         log_message("[StaticData] m_State is NULL");
         return NULL;
@@ -691,47 +686,47 @@ static void* hook_GetActionResource(void* headmaster) {
  * Uses standard Dobby hooks (Get<T> functions are small and typically safe).
  */
 static void install_get_manager_hooks(void* main_binary_base) {
+    (void)main_binary_base;  // address now sourced from offset_table
+    const VersionOffsets *off = offset_table_get();
+    if (!off) {
+        log_message("[StaticData] Get<T> hooks SKIPPED (no offset table entry for this version)");
+        return;
+    }
+
+    // CRASH GUARD: these Get<T> accessors are hooked with PLAIN DobbyHook, which
+    // mangles their PC-relative (adrp/cbz) prologue on shifted versions — the
+    // trampoline then returns a garbage manager and the character-progression
+    // validator calls through a bad pointer (e.g. Barbarian level 2->3 subclass
+    // pick -> SIGBUS, with zero SE frames in the stack). Only install on the
+    // exact baseline version where DobbyHook is known-safe. On other versions the
+    // TypeContext traversal (capture_managers_via_typecontext) already captures
+    // these managers without hooking, so StaticData degrades gracefully.
+    // (Proper future fix: give Get<T> the same ADRP-safe install FeatManager uses.)
+    if (!version_detect_matches()) {
+        log_message("[StaticData] Get<T> code hooks SKIPPED on this version "
+                    "(plain DobbyHook is prologue-unsafe) — using TypeContext traversal only");
+        return;
+    }
+
     log_message("[StaticData] Installing Get<T> hooks for real manager capture...");
+    void* target;
 
-    // Background
-    void* target = (uint8_t*)main_binary_base + OFFSET_GET_BACKGROUND;
-    if (DobbyHook(target, (void*)hook_GetBackground, (void**)&g_orig_GetBackground) == 0) {
-        log_message("[StaticData] Installed Get<BackgroundManager> hook at %p", target);
-    } else {
-        log_message("[StaticData] WARNING: Failed to hook Get<BackgroundManager>");
+#define INSTALL_HOOK(field, fn_hook, fn_orig, label) \
+    if (off->field) { \
+        target = offset_table_fn(off->field); \
+        if (DobbyHook(target, (void*)(fn_hook), (void**)(fn_orig)) == 0) \
+            log_message("[StaticData] Installed " label " hook at %p", target); \
+        else \
+            log_message("[StaticData] WARNING: Failed to hook " label); \
     }
 
-    // Origin
-    target = (uint8_t*)main_binary_base + OFFSET_GET_ORIGIN;
-    if (DobbyHook(target, (void*)hook_GetOrigin, (void**)&g_orig_GetOrigin) == 0) {
-        log_message("[StaticData] Installed Get<OriginManager> hook at %p", target);
-    } else {
-        log_message("[StaticData] WARNING: Failed to hook Get<OriginManager>");
-    }
+    INSTALL_HOOK(fn_get_background,    hook_GetBackground,    &g_orig_GetBackground,    "Get<BackgroundManager>")
+    INSTALL_HOOK(fn_get_origin,        hook_GetOrigin,        &g_orig_GetOrigin,        "Get<OriginManager>")
+    INSTALL_HOOK(fn_get_class,         hook_GetClass,         &g_orig_GetClass,         "Get<ClassDescriptions>")
+    INSTALL_HOOK(fn_get_progression,   hook_GetProgression,   &g_orig_GetProgression,   "Get<ProgressionManager>")
+    INSTALL_HOOK(fn_get_actionresource,hook_GetActionResource,&g_orig_GetActionResource,"Get<ActionResourceTypes>")
 
-    // Class
-    target = (uint8_t*)main_binary_base + OFFSET_GET_CLASS;
-    if (DobbyHook(target, (void*)hook_GetClass, (void**)&g_orig_GetClass) == 0) {
-        log_message("[StaticData] Installed Get<ClassDescriptions> hook at %p", target);
-    } else {
-        log_message("[StaticData] WARNING: Failed to hook Get<ClassDescriptions>");
-    }
-
-    // Progression
-    target = (uint8_t*)main_binary_base + OFFSET_GET_PROGRESSION;
-    if (DobbyHook(target, (void*)hook_GetProgression, (void**)&g_orig_GetProgression) == 0) {
-        log_message("[StaticData] Installed Get<ProgressionManager> hook at %p", target);
-    } else {
-        log_message("[StaticData] WARNING: Failed to hook Get<ProgressionManager>");
-    }
-
-    // ActionResource
-    target = (uint8_t*)main_binary_base + OFFSET_GET_ACTIONRESOURCE;
-    if (DobbyHook(target, (void*)hook_GetActionResource, (void**)&g_orig_GetActionResource) == 0) {
-        log_message("[StaticData] Installed Get<ActionResourceTypes> hook at %p", target);
-    } else {
-        log_message("[StaticData] WARNING: Failed to hook Get<ActionResourceTypes>");
-    }
+#undef INSTALL_HOOK
 
     log_message("[StaticData] Get<T> hooks installation complete");
 }
@@ -983,7 +978,26 @@ int staticdata_hash_lookup_capture(void) {
  * Returns true if hook was installed successfully.
  */
 static bool install_feat_getfeats_safe_hook(void* main_binary_base) {
-    void* target = (uint8_t*)main_binary_base + OFFSET_FEAT_GETFEATS;
+    const VersionOffsets *off = offset_table_get();
+    if (!off || !off->fn_feat_getfeats) {
+        log_message("[StaticData] FeatGetFeats offset not available for this version");
+        return false;
+    }
+
+    // CRASH GUARD: this hook fires during character level-up (it captures the
+    // session FeatManager). Even the ARM64-safe hook's trampoline is not proven
+    // correct on shifted prologues — a corrupted accessor crashes the level-up
+    // validator (ApplyAndValidateLevelUp -> indirect call to garbage; zero SE
+    // frames). Only install on the exact baseline version where it's verified.
+    // On other versions StaticData captures FeatManager via the TypeContext
+    // traversal instead (no hooking). Restores the pre-offset-table-fill behavior.
+    if (!version_detect_matches()) {
+        log_message("[StaticData] FeatManager::GetFeats hook SKIPPED on this version "
+                    "(hook trampoline unverified) — using TypeContext traversal only");
+        return false;
+    }
+
+    void* target = offset_table_fn(off->fn_feat_getfeats);
 
     // First, analyze the prologue to understand the ADRP patterns
     log_message("[StaticData] Analyzing FeatManager::GetFeats prologue at %p", target);
@@ -1049,6 +1063,20 @@ bool staticdata_manager_init(void *main_binary_base) {
     // Clear manager pointers
     memset(g_staticdata.managers, 0, sizeof(g_staticdata.managers));
     memset(g_staticdata.real_managers, 0, sizeof(g_staticdata.real_managers));
+
+    // Manager capture installs inline Dobby CODE hooks at function addresses.
+    // Addresses are sourced from the offset table (keyed by game version).
+    // A missing table entry means 0 offsets → hooks are individually skipped.
+    // This replaced the old exact-version-match gate (Issue #78) with a
+    // per-version table so new BG3 versions can be supported without source changes.
+    const VersionOffsets *off = offset_table_get();
+    if (!off || (!off->fn_feat_getfeats && !off->fn_get_background)) {
+        log_message("[StaticData] Manager hooks SKIPPED (no function offsets for version %s — "
+                    "add to offset_table.c to enable; Ext.StaticData in degraded mode)",
+                    version_detect_get_version() ? version_detect_get_version() : "unknown");
+        g_staticdata.initialized = true;
+        return true;
+    }
 
     // Try to install ARM64-safe hook for FeatManager::GetFeats
     // This uses the skip-and-redirect strategy from Issue #44

--- a/src/stats/functor_hooks.c
+++ b/src/stats/functor_hooks.c
@@ -17,6 +17,7 @@
 #include "functor_hooks.h"
 #include "functor_types.h"
 #include "../core/logging.h"
+#include "../core/offset_table.h"
 #include "../lua/lua_events.h"
 #include "../lua/lua_gate.h"
 #include "../entity/entity_storage.h"
@@ -54,7 +55,11 @@ extern void* entity_get_binary_base(void);
 static uintptr_t get_runtime_addr(uintptr_t ghidra_addr) {
     void* base = entity_get_binary_base();
     if (!base) return 0;
-    return ghidra_addr - GHIDRA_BASE_ADDRESS + (uintptr_t)base;
+    // Remap the hardcoded 6995620 address to the running version (0 = no verified
+    // address -> caller skips the hook instead of hooking a stale function).
+    uint64_t remapped = offset_table_remap_fn(ghidra_addr);
+    if (!remapped) return 0;
+    return remapped - GHIDRA_BASE_ADDRESS + (uintptr_t)base;
 }
 
 // =============================================================================

--- a/src/stats/prototype_managers.c
+++ b/src/stats/prototype_managers.c
@@ -176,14 +176,15 @@ static SpellPrototypeInit_fn g_SpellPrototypeInit = NULL;
 // ============================================================================
 
 // Resolve a __DATA Ghidra address (prototype-manager singleton pointer) to a
-// runtime address, applying the per-version __DATA shift (e.g. +0x8000 for
-// 7209685). All callers of this helper are __DATA globals; the Init *function*
+// runtime address. The compiled-in constants are 4.1.1.7209685-vintage
+// (nm-derived); component_data_shift is the signed delta from that vintage to
+// the running version (0 on 7209685, -0x8000 on 6995620). The Init *function*
 // (a __TEXT address with a different per-version shift) is resolved separately
 // via the offset table.
 static void* ghidra_to_runtime(uint64_t ghidra_addr) {
     if (!g_MainBinaryBase) return NULL;
     const VersionOffsets *off = offset_table_get();
-    uintptr_t shift = off ? off->component_data_shift : 0;
+    intptr_t shift = off ? off->component_data_shift : 0;
     return (void*)((uintptr_t)g_MainBinaryBase + (ghidra_addr - GHIDRA_BASE_ADDRESS) + shift);
 }
 

--- a/src/stats/prototype_managers.c
+++ b/src/stats/prototype_managers.c
@@ -9,6 +9,7 @@
 #include "stats_manager.h"
 #include "logging.h"
 #include "../core/version_detect.h"
+#include "../core/offset_table.h"
 #include "../strings/fixed_string.h"
 
 #include <stdio.h>
@@ -174,9 +175,16 @@ static SpellPrototypeInit_fn g_SpellPrototypeInit = NULL;
 // Helper: Calculate runtime address from Ghidra offset
 // ============================================================================
 
+// Resolve a __DATA Ghidra address (prototype-manager singleton pointer) to a
+// runtime address, applying the per-version __DATA shift (e.g. +0x8000 for
+// 7209685). All callers of this helper are __DATA globals; the Init *function*
+// (a __TEXT address with a different per-version shift) is resolved separately
+// via the offset table.
 static void* ghidra_to_runtime(uint64_t ghidra_addr) {
     if (!g_MainBinaryBase) return NULL;
-    return (void*)((uintptr_t)g_MainBinaryBase + (ghidra_addr - GHIDRA_BASE_ADDRESS));
+    const VersionOffsets *off = offset_table_get();
+    uintptr_t shift = off ? off->component_data_shift : 0;
+    return (void*)((uintptr_t)g_MainBinaryBase + (ghidra_addr - GHIDRA_BASE_ADDRESS) + shift);
 }
 
 // ============================================================================
@@ -234,11 +242,19 @@ bool prototype_managers_init(void *main_binary_base) {
                     (void*)g_pStatusPrototypeManagerPtr,
                     (unsigned long long)OFFSET_STATUS_PROTOTYPE_MANAGER_PTR);
 
-    // Resolve Init function pointers
-    g_SpellPrototypeInit = (SpellPrototypeInit_fn)ghidra_to_runtime(OFFSET_SPELL_PROTOTYPE_INIT);
-    LOG_STATS_DEBUG("[PrototypeManagers] SpellPrototype::Init at: %p (Ghidra: 0x%llx)",
-                    (void*)g_SpellPrototypeInit,
-                    (unsigned long long)OFFSET_SPELL_PROTOTYPE_INIT);
+    // Resolve Init function pointer from the per-version offset table (it's a
+    // __TEXT address with a version-specific shift different from __DATA, so it
+    // can't go through ghidra_to_runtime). If unavailable, leave NULL so
+    // sync_spell_prototype skips the Init call instead of jumping to a stale
+    // address (the bug that crashed Ext.Stats.Sync on 7209685).
+    {
+        const VersionOffsets *off = offset_table_get();
+        g_SpellPrototypeInit = (off && off->fn_spell_proto_init)
+            ? (SpellPrototypeInit_fn)offset_table_fn(off->fn_spell_proto_init)
+            : NULL;
+        LOG_STATS_DEBUG("[PrototypeManagers] SpellPrototype::Init at: %p",
+                        (void*)g_SpellPrototypeInit);
+    }
 
     g_Initialized = true;
     LOG_STATS_DEBUG("[PrototypeManagers] Initialization complete");

--- a/src/stats/stats_manager.c
+++ b/src/stats/stats_manager.c
@@ -16,6 +16,8 @@
 #include "prototype_managers.h"
 #include "logging.h"
 #include "../strings/fixed_string.h"
+#include "../core/offset_table.h"
+#include "../game/game_state.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -286,14 +288,21 @@ void stats_manager_init(void *main_binary_base) {
         }
     }
 
-    // Fallback: Calculate from Ghidra offset
+    // Fallback: use offset table (version-keyed), then old Ghidra absolute if nothing else
     if (!g_pRPGStatsPtr && main_binary_base) {
-        uintptr_t runtime_addr = (uintptr_t)main_binary_base +
-                                  (OFFSET_RPGSTATS_M_PTR - GHIDRA_BASE_ADDRESS);
-        g_pRPGStatsPtr = (void**)runtime_addr;
-        LOG_STATS_DEBUG("Using Ghidra offset: %p (base %p + offset 0x%llx)",
-                  (void*)g_pRPGStatsPtr, main_binary_base,
-                  (unsigned long long)(OFFSET_RPGSTATS_M_PTR - GHIDRA_BASE_ADDRESS));
+        const VersionOffsets *off = offset_table_get();
+        if (off && off->rpgstats_ptr) {
+            g_pRPGStatsPtr = (void**)offset_table_resolve(off->rpgstats_ptr);
+            LOG_STATS_DEBUG("Using offset table: %p (offset 0x%llx)",
+                      (void*)g_pRPGStatsPtr, (unsigned long long)off->rpgstats_ptr);
+        } else {
+            uintptr_t runtime_addr = (uintptr_t)main_binary_base +
+                                      (OFFSET_RPGSTATS_M_PTR - GHIDRA_BASE_ADDRESS);
+            g_pRPGStatsPtr = (void**)runtime_addr;
+            LOG_STATS_DEBUG("Using Ghidra offset fallback: %p (base %p + offset 0x%llx)",
+                      (void*)g_pRPGStatsPtr, main_binary_base,
+                      (unsigned long long)(OFFSET_RPGSTATS_M_PTR - GHIDRA_BASE_ADDRESS));
+        }
     }
 
     g_Initialized = true;
@@ -1422,6 +1431,18 @@ static void* get_cached_vmt(void) {
 
 bool stats_sync(const char *name) {
     if (!name) return false;
+
+    // CRASH GUARD: stats_sync is a *mutating* op — it calls the game's
+    // SpellPrototype::Init on prototypes held in the manager's RefMap. During a
+    // session load/unload/sync the game is rebuilding those managers, so a
+    // prototype pointer can be freed mid-call (use-after-free -> SIGBUS). Only
+    // run when the server is in a stable state.
+    ServerGameState gs = game_state_get_current();
+    if (gs != SERVER_STATE_RUNNING && gs != SERVER_STATE_PAUSED) {
+        LOG_STATS_DEBUG("stats_sync: skipped for '%s' — server not stable (state=%s)",
+                        name, game_state_get_name(gs));
+        return false;
+    }
 
     // Get the stat object (shadow or game)
     StatsObjectPtr obj = stats_get(name);

--- a/src/stats/stats_manager.c
+++ b/src/stats/stats_manager.c
@@ -17,6 +17,7 @@
 #include "logging.h"
 #include "../strings/fixed_string.h"
 #include "../core/offset_table.h"
+#include "../core/version_detect.h"
 #include "../game/game_state.h"
 
 #include <stdio.h>
@@ -288,20 +289,25 @@ void stats_manager_init(void *main_binary_base) {
         }
     }
 
-    // Fallback: use offset table (version-keyed), then old Ghidra absolute if nothing else
+    // Fallback: use offset table (version-keyed). The hardcoded Ghidra define is
+    // allowed only when the binary is the exact audited build; on any other
+    // version we fail closed (stats disabled) rather than read a stale slot.
     if (!g_pRPGStatsPtr && main_binary_base) {
         const VersionOffsets *off = offset_table_get();
         if (off && off->rpgstats_ptr) {
             g_pRPGStatsPtr = (void**)offset_table_resolve(off->rpgstats_ptr);
             LOG_STATS_DEBUG("Using offset table: %p (offset 0x%llx)",
                       (void*)g_pRPGStatsPtr, (unsigned long long)off->rpgstats_ptr);
-        } else {
+        } else if (version_detect_matches()) {
             uintptr_t runtime_addr = (uintptr_t)main_binary_base +
                                       (OFFSET_RPGSTATS_M_PTR - GHIDRA_BASE_ADDRESS);
             g_pRPGStatsPtr = (void**)runtime_addr;
             LOG_STATS_DEBUG("Using Ghidra offset fallback: %p (base %p + offset 0x%llx)",
                       (void*)g_pRPGStatsPtr, main_binary_base,
                       (unsigned long long)(OFFSET_RPGSTATS_M_PTR - GHIDRA_BASE_ADDRESS));
+        } else {
+            LOG_STATS_INFO("No verified RPGStats slot for this game version — "
+                           "stats system disabled (fail closed)");
         }
     }
 

--- a/src/strings/fixed_string.c
+++ b/src/strings/fixed_string.c
@@ -13,6 +13,7 @@
 #include "fixed_string.h"
 #include "../core/logging.h"
 #include "../core/version.h"
+#include "../core/offset_table.h"
 #include <mach/mach.h>
 #include <mach-o/dyld.h>
 #include <dlfcn.h>
@@ -1123,6 +1124,28 @@ void fixed_string_init(void *main_binary_base) {
     g_MainBinaryBase = main_binary_base;
     LOG_CORE_DEBUG("Initializing with binary base %p", main_binary_base);
 
+    // Highest priority: per-version offset table (authoritative; beats the
+    // stale on-disk cache and the hardcoded Ghidra fallback below). The slot
+    // holds a pointer to the GlobalStringTable.
+    {
+        const VersionOffsets *off = offset_table_get();
+        if (off && off->gst_ptr && main_binary_base) {
+            static void *gst_slot = NULL;
+            gst_slot = (void *)((uintptr_t)main_binary_base + off->gst_ptr);
+            void *gst = NULL;
+            if (safe_read_ptr(gst_slot, &gst) && gst) {
+                g_pGlobalStringTable = (void **)gst_slot;
+                LOG_CORE_DEBUG("GST from offset table: slot=%p GST=%p", gst_slot, gst);
+                if (fixed_string_probe_offsets()) {
+                    g_Initialized = true;
+                    LOG_CORE_DEBUG("Initialization complete via offset table");
+                    return;
+                }
+                g_pGlobalStringTable = NULL;  // probe failed; fall through
+            }
+        }
+    }
+
     // Try dlsym first
     g_pGlobalStringTable = try_dlsym_discovery();
 
@@ -1181,6 +1204,28 @@ static bool try_lazy_discovery(void) {
 
     LOG_CORE_DEBUG("Lazy discovery triggered on first resolution attempt...");
 
+    // Strategy 0: per-version offset table (authoritative). Re-checked here
+    // because fixed_string_init() may run before the offset table is loaded;
+    // by first resolution the table is guaranteed populated. The slot holds a
+    // pointer to the GlobalStringTable.
+    {
+        const VersionOffsets *off = offset_table_get();
+        if (off && off->gst_ptr && g_MainBinaryBase) {
+            static void *gst_slot = NULL;
+            gst_slot = (void *)((uintptr_t)g_MainBinaryBase + off->gst_ptr);
+            void *gst = NULL;
+            if (safe_read_ptr(gst_slot, &gst) && gst) {
+                g_pGlobalStringTable = (void **)gst_slot;
+                LOG_CORE_DEBUG("GST from offset table (lazy): slot=%p GST=%p", gst_slot, gst);
+                if (fixed_string_probe_offsets()) {
+                    LOG_CORE_DEBUG("Lazy discovery via offset table succeeded");
+                    return true;
+                }
+                g_pGlobalStringTable = NULL;  // probe failed; fall through
+            }
+        }
+    }
+
     // Strategy 1: Try to load from cache (instant - no scanning needed)
     if (load_offset_cache() && g_CachedGSTOffset != 0 && g_MainBinaryBase) {
         uintptr_t gst_addr = (uintptr_t)g_MainBinaryBase + g_CachedGSTOffset;
@@ -1228,14 +1273,54 @@ static bool try_lazy_discovery(void) {
 // Resolution
 // ============================================================================
 
+/**
+ * Ensure the GlobalStringTable is resolved, RETRYING via the per-version offset
+ * table on every call until the game has actually created it. fixed_string_init
+ * runs early (GST pointer still null), so a one-shot lazy discovery would cache
+ * that failure forever. The offset-table slot is cheap to re-read, so we poll it
+ * until non-null, then probe the SubTable layout once.
+ */
+static bool g_GstOffsetsProbed = false;
+static bool ensure_gst(void) {
+    // Already have a working GST?
+    if (g_pGlobalStringTable && *g_pGlobalStringTable && g_GstOffsetsProbed) {
+        return true;
+    }
+
+    const VersionOffsets *off = offset_table_get();
+    if (off && off->gst_ptr && g_MainBinaryBase) {
+        static void *gst_slot = NULL;
+        gst_slot = (void *)((uintptr_t)g_MainBinaryBase + off->gst_ptr);
+        void *gst = NULL;
+        if (safe_read_ptr(gst_slot, &gst) && gst) {
+            g_pGlobalStringTable = (void **)gst_slot;
+            if (!g_GstOffsetsProbed) {
+                if (fixed_string_probe_offsets()) {
+                    g_GstOffsetsProbed = true;
+                    LOG_CORE_DEBUG("GST ready via offset table (retry): %p", gst);
+                } else {
+                    g_pGlobalStringTable = NULL;  // layout probe not ready yet; retry next call
+                    return false;
+                }
+            }
+            return true;
+        }
+        // GST slot still null — game hasn't created it yet; caller retries later.
+        return false;
+    }
+
+    // No offset-table entry for this version: fall back to one-shot lazy discovery.
+    return try_lazy_discovery();
+}
+
 const char *fixed_string_resolve(uint32_t index) {
     if (index == FS_NULL_INDEX) {
         return NULL;
     }
 
-    // Try lazy discovery if GST not found yet
-    if (!g_pGlobalStringTable) {
-        if (!try_lazy_discovery()) {
+    // Ensure GST is resolved (retries via offset table until the game creates it)
+    if (!g_pGlobalStringTable || !*g_pGlobalStringTable || !g_GstOffsetsProbed) {
+        if (!ensure_gst()) {
             g_FailedCount++;
             return NULL;
         }
@@ -1418,9 +1503,15 @@ static bool init_intern_function(void) {
         return false;
     }
 
-    // Calculate runtime address from Ghidra offset
+    // Remap the hardcoded 6995620 address to the running version's address.
+    uint64_t create_addr = offset_table_remap_fn(GHIDRA_FIXEDSTRING_CREATE);
+    if (!create_addr) {
+        LOG_CORE_WARN("FixedString::Create has no verified address for this version — interning disabled");
+        g_FixedStringCreate = NULL;
+        return false;
+    }
     uintptr_t runtime_addr = (uintptr_t)g_MainBinaryBase +
-                              (GHIDRA_FIXEDSTRING_CREATE - GHIDRA_BASE_ADDRESS);
+                              (create_addr - GHIDRA_BASE_ADDRESS);
 
     g_FixedStringCreate = (FixedStringCreate_t)runtime_addr;
 
@@ -1475,9 +1566,9 @@ uint32_t fixed_string_get_hash(uint32_t index) {
         return 0;
     }
 
-    // Try lazy discovery if GST not found yet
-    if (!g_pGlobalStringTable) {
-        if (!try_lazy_discovery()) {
+    // Ensure GST is resolved (retries via offset table until the game creates it)
+    if (!g_pGlobalStringTable || !*g_pGlobalStringTable || !g_GstOffsetsProbed) {
+        if (!ensure_gst()) {
             return 0;
         }
     }

--- a/src/template/template_manager.c
+++ b/src/template/template_manager.c
@@ -8,6 +8,8 @@
 #include "template_manager.h"
 #include "../core/logging.h"
 #include "../core/safe_memory.h"
+#include "../core/version_detect.h"
+#include "../core/offset_table.h"
 #include "../strings/fixed_string.h"
 #include "../hooks/arm64_hook.h"
 #include <string.h>
@@ -206,35 +208,39 @@ static bool install_arm64_safe_hook(const char* name, void* target, void* hook_f
  * Returns true if at least one manager was captured.
  */
 static bool template_read_global_pointers(void* main_binary_base) {
-    if (!main_binary_base) return false;
+    (void)main_binary_base;  // addresses now sourced from offset_table
+
+    const VersionOffsets *off = offset_table_get();
+    if (!off) return false;
 
     int captured = 0;
+    void *mgr = NULL;
 
-    // Read GlobalTemplateManager::m_ptr
-    void** global_mgr_ptr = (void**)((uintptr_t)main_binary_base + OFFSET_GLOBAL_TEMPLATE_MANAGER_PTR);
-    void* global_mgr = *global_mgr_ptr;
-    if (global_mgr && !g_template.managers[TEMPLATE_MANAGER_GLOBAL_BANK]) {
-        g_template.managers[TEMPLATE_MANAGER_GLOBAL_BANK] = global_mgr;
-        log_message("[Template] Captured GlobalTemplateManager: %p (from global ptr)", global_mgr);
-        captured++;
+    if (off->global_template_mgr_ptr && !g_template.managers[TEMPLATE_MANAGER_GLOBAL_BANK]) {
+        void *slot = offset_table_resolve(off->global_template_mgr_ptr);
+        if (slot && safe_memory_read_pointer((mach_vm_address_t)slot, &mgr) && mgr) {
+            g_template.managers[TEMPLATE_MANAGER_GLOBAL_BANK] = mgr;
+            log_message("[Template] Captured GlobalTemplateManager: %p", mgr);
+            captured++;
+        }
     }
 
-    // Read CacheTemplateManager::m_ptr
-    void** cache_mgr_ptr = (void**)((uintptr_t)main_binary_base + OFFSET_CACHE_TEMPLATE_MANAGER_PTR);
-    void* cache_mgr = *cache_mgr_ptr;
-    if (cache_mgr && !g_template.managers[TEMPLATE_MANAGER_CACHE]) {
-        g_template.managers[TEMPLATE_MANAGER_CACHE] = cache_mgr;
-        log_message("[Template] Captured CacheTemplateManager: %p (from global ptr)", cache_mgr);
-        captured++;
+    if (off->cache_template_mgr_ptr && !g_template.managers[TEMPLATE_MANAGER_CACHE]) {
+        void *slot = offset_table_resolve(off->cache_template_mgr_ptr);
+        if (slot && safe_memory_read_pointer((mach_vm_address_t)slot, &mgr) && mgr) {
+            g_template.managers[TEMPLATE_MANAGER_CACHE] = mgr;
+            log_message("[Template] Captured CacheTemplateManager: %p", mgr);
+            captured++;
+        }
     }
 
-    // Read Level::s_CacheTemplateManager (level-local cache)
-    void** level_cache_ptr = (void**)((uintptr_t)main_binary_base + OFFSET_LEVEL_CACHE_MANAGER_PTR);
-    void* level_cache = *level_cache_ptr;
-    if (level_cache && !g_template.managers[TEMPLATE_MANAGER_LOCAL_CACHE]) {
-        g_template.managers[TEMPLATE_MANAGER_LOCAL_CACHE] = level_cache;
-        log_message("[Template] Captured Level::CacheTemplateManager: %p (from global ptr)", level_cache);
-        captured++;
+    if (off->level_cache_mgr_ptr && !g_template.managers[TEMPLATE_MANAGER_LOCAL_CACHE]) {
+        void *slot = offset_table_resolve(off->level_cache_mgr_ptr);
+        if (slot && safe_memory_read_pointer((mach_vm_address_t)slot, &mgr) && mgr) {
+            g_template.managers[TEMPLATE_MANAGER_LOCAL_CACHE] = mgr;
+            log_message("[Template] Captured Level::CacheTemplateManager: %p", mgr);
+            captured++;
+        }
     }
 
     return captured > 0;
@@ -255,10 +261,18 @@ bool template_install_hooks(void* main_binary_base) {
 
     g_template.main_binary_base = main_binary_base;
 
+    const VersionOffsets *off = offset_table_get();
     log_message("[Template] Using global pointer read approach (no hooks needed)");
-    log_message("[Template]   GlobalTemplateManager::m_ptr at offset 0x%x", OFFSET_GLOBAL_TEMPLATE_MANAGER_PTR);
-    log_message("[Template]   CacheTemplateManager::m_ptr at offset 0x%x", OFFSET_CACHE_TEMPLATE_MANAGER_PTR);
-    log_message("[Template]   Level::s_CacheTemplateManager at offset 0x%x", OFFSET_LEVEL_CACHE_MANAGER_PTR);
+    if (off) {
+        log_message("[Template]   GlobalTemplateManager::m_ptr offset 0x%llx",
+                    (unsigned long long)off->global_template_mgr_ptr);
+        log_message("[Template]   CacheTemplateManager::m_ptr offset 0x%llx",
+                    (unsigned long long)off->cache_template_mgr_ptr);
+        log_message("[Template]   Level::s_CacheTemplateManager offset 0x%llx",
+                    (unsigned long long)off->level_cache_mgr_ptr);
+    } else {
+        log_message("[Template]   No offset table entry for this version — pointers may not resolve");
+    }
 
     // Try to read managers now (may be NULL if called early)
     bool captured = template_read_global_pointers(main_binary_base);
@@ -436,14 +450,17 @@ bool template_manager_init(void* main_binary_base) {
     memset(g_template.managers, 0, sizeof(g_template.managers));
     memset(g_template.template_counts, -1, sizeof(g_template.template_counts));
 
-    // Install auto-capture hooks
-    if (main_binary_base) {
+    // template_install_hooks reads global singleton pointers from the offset table.
+    // It is safe to call whenever a table entry exists (no code patching involved).
+    if (main_binary_base && offset_table_get()) {
         bool hooks_ok = template_install_hooks(main_binary_base);
         if (hooks_ok) {
-            log_message("[Template] Auto-capture hooks installed (waiting for game activity)");
+            log_message("[Template] Template pointers initialized");
         } else {
-            log_message("[Template] Failed to install auto-capture hooks, falling back to Frida capture");
+            log_message("[Template] Template pointers not yet available, will retry on first access");
         }
+    } else if (main_binary_base) {
+        log_message("[Template] Skipping pointer reads (no offset table entry for this version)");
     }
 
     g_template.initialized = true;

--- a/tests/harness/test_offset_audit.py
+++ b/tests/harness/test_offset_audit.py
@@ -1,21 +1,35 @@
-"""Audit hardcoded code-patch offsets against the installed game binary.
+"""Audit hardcoded offsets and the per-version offset table against the
+installed game binary.
 
-Dobby code patches aimed at the main BG3 binary use hardcoded addresses
-derived from one specific game build. The version-detect sentinels only
-validate three *data* addresses, so a game update can silently invalidate
-*code* offsets — a stale ``OFFSET_GET_CLASS`` once landed in the middle of
-``gui::HotbarSystem::Update`` and crashed every session ~30s after save
-load (docs/bugs/codex-debugger-nohooks-2026-07-28.md).
+Dobby code patches and singleton reads aimed at the main BG3 binary use
+hardcoded addresses derived from one specific game build. The version-detect
+sentinels only validate three *data* addresses, so a game update can silently
+invalidate *code* offsets — a stale ``OFFSET_GET_CLASS`` once landed in the
+middle of ``gui::HotbarSystem::Update`` and crashed every session ~30s after
+save load (docs/bugs/codex-debugger-nohooks-2026-07-28.md).
 
-This test parses the offsets out of the C sources and asserts that ``nm``
-resolves each one to exactly the symbol it claims to target. It skips when
-the game binary is not installed (CI).
+Three audit layers, all skipped when the game binary is absent (CI):
 
-COVERAGE LIMIT: the eleven functor-hook addresses in
-``src/stats/functor_types.h`` target STRIPPED LOCAL functions with no nm
-symbols, so this audit cannot validate them. That family is instead gated
-at install time on ``FUNCTOR_ADDRS_VERIFIED_BUILD`` — an exact match
-against the build its addresses were derived from, independent of
+1. ``AUDITED_OFFSETS`` — #defines parsed out of C sources, resolved via nm.
+2. The 4.1.1.7209685 row of ``src/core/offset_table.c`` — every field except
+   the documented exclusions must resolve to its claimed symbol.
+   Exclusions: ``staticdata_mstate_ptr`` is a ``__DATA_CONST,__got`` slot
+   (validated GOT-aware via ``otool -Iv`` instead — nm cannot see it);
+   ``global_switches_ptr`` is an anonymous __common slot with no symbol
+   (verified 2026-07-29 by disassembly: 916 refs across 593 functions incl.
+   App::CreateGlobalSwitches; runtime read-back guard in global_switches.c);
+   ``component_data_shift`` is a delta, not an address.
+3. The two-column function remap in ``offset_table.c`` — every nonzero
+   7209685 address must have a symbol at that VA, and no address may appear
+   in more than one row (either-column matching must be collision-free).
+
+FUNCTOR GATE: the eleven functor-hook addresses in
+``src/stats/functor_types.h`` ARE nm-visible local symbols on 7209685 (the
+old "stripped locals" premise was wrong), but the 7209685 Interrupt variant
+gained a leading ``ecs::EntityWorld&`` parameter — address validity is not
+ABI validity. The family therefore stays gated at install time on
+``FUNCTOR_ADDRS_VERIFIED_BUILD`` — an exact match against the build its
+addresses AND wrapper ABIs were verified on, independent of
 ``BG3_KNOWN_VERSION`` (see test_functor_gate_is_independent below).
 """
 
@@ -29,26 +43,11 @@ import pytest
 from bg3se_harness.config import BG3_EXEC
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+OFFSET_TABLE_C = REPO_ROOT / "src/core/offset_table.c"
 
 # (source file, #define name, expected demangled symbol substring,
-#  base-relative? — staticdata offsets are relative to 0x100000000)
+#  base-relative? — offsets below 0x100000000 are relative to the image base)
 AUDITED_OFFSETS = [
-    ("src/staticdata/staticdata_manager.c", "OFFSET_FEAT_GETFEATS",
-     "eoc::FeatManager::GetFeats() const", True),
-    ("src/staticdata/staticdata_manager.c", "OFFSET_GETALLFEATS",
-     "eoc::character_creation::GetAllFeats", True),
-    ("src/staticdata/staticdata_manager.c", "OFFSET_MSTATE_PTR",
-     "ls::TypeContext<ls::ImmutableDataHeadmaster>::m_State", True),
-    ("src/staticdata/staticdata_manager.c", "OFFSET_GET_BACKGROUND",
-     "ImmutableDataHeadmaster::Get<eoc::BackgroundManager>", True),
-    ("src/staticdata/staticdata_manager.c", "OFFSET_GET_ORIGIN",
-     "ImmutableDataHeadmaster::Get<eoc::OriginManager>", True),
-    ("src/staticdata/staticdata_manager.c", "OFFSET_GET_CLASS",
-     "ImmutableDataHeadmaster::Get<eoc::ClassDescriptions>", True),
-    ("src/staticdata/staticdata_manager.c", "OFFSET_GET_PROGRESSION",
-     "ImmutableDataHeadmaster::Get<eoc::ProgressionManager>", True),
-    ("src/staticdata/staticdata_manager.c", "OFFSET_GET_ACTIONRESOURCE",
-     "ImmutableDataHeadmaster::Get<eoc::ActionResourceTypes>", True),
     ("src/network/protocol.h", "ADDR_GETMESSAGE",
      "net::MessageFactory::GetFreeMessage(int)", False),
     ("src/game/video_skip.c", "VA_BINK_LOAD_VIDEO",
@@ -85,7 +84,49 @@ AUDITED_OFFSETS = [
      "ls::ResourceManager::m_ptr", True),
     ("src/resource/resource_manager.c", "OFFSET_GETRESOURCE_FUNC",
      "ls::ResourceContainer::GetResource", True),
+    ("src/localization/localization.c", "LOCA_REPO_OFFSET",
+     "ls::TranslatedStringRepository::m_ptr", True),
+    ("src/localization/localization.c", "LOCA_TRYGET_OFFSET",
+     "ls::TranslatedStringRepository::TryGet", True),
+    ("src/localization/localization.c", "LOCA_FIXEDSTRING_CREATE",
+     "ls::FixedString::Create(char const*, int)", True),
+    ("src/localization/localization.c", "LOCA_ADDTRANSLATEDSTRING",
+     "ls::TranslatedStringRepository::AddTranslatedString", True),
+    ("src/audio/audio_manager.c", "OFFSET_STDSTRING_CTOR",
+     "ls::STDString::STDString(char const*)", True),
 ]
+
+# Expected symbol per 7209685-row field in offset_table.c.
+# None = documented exclusion (see module docstring).
+TABLE_FIELD_SYMBOLS = {
+    "eocserver_ptr":           "esv::EocServer::m_ptr",
+    "eocclient_ptr":           "ecl::EocClient::m_ptr",
+    "spell_proto_mgr_ptr":     "eoc::SpellPrototypeManager::m_ptr",
+    "rpgstats_ptr":            "RPGStats::m_ptr",
+    "resource_mgr_ptr":        "ls::ResourceManager::m_ptr",
+    "level_mgr_ptr":           "esv::LevelManager::m_ptr",
+    "global_template_mgr_ptr": "ls::GlobalTemplateManager::m_ptr",
+    "cache_template_mgr_ptr":  "esv::CacheTemplateManager::m_ptr",
+    "level_cache_mgr_ptr":     "esv::Level::s_CacheTemplateManager",
+    "staticdata_mstate_ptr":   None,  # __got slot — see test_mstate_got_slot
+    "gst_ptr":                 "ls::gst::s_Instance",
+    "global_switches_ptr":     None,  # anonymous __common slot, no symbol
+    "fn_feat_getfeats":        "eoc::FeatManager::GetFeats",
+    "fn_getallfeats":          "eoc::character_creation::GetAllFeats",
+    "fn_get_background":       "ImmutableDataHeadmaster::Get<eoc::BackgroundManager>",
+    "fn_get_origin":           "ImmutableDataHeadmaster::Get<eoc::OriginManager>",
+    "fn_get_class":            "ImmutableDataHeadmaster::Get<eoc::ClassDescriptions>",
+    "fn_get_progression":      "ImmutableDataHeadmaster::Get<eoc::ProgressionManager>",
+    "fn_get_actionresource":   "ImmutableDataHeadmaster::Get<eoc::ActionResourceTypes>",
+    "fn_get_template_raw":     "ls::GlobalTemplateManager::GetTemplateRaw",
+    "fn_cache_template":       "ls::CacheTemplateManagerBase::CacheTemplate",
+    "fn_try_get_uuid_mapping": "ToHandleMappingComponent",
+    "fn_storage_tryget":       "ecs::EntityStorageContainer::TryGet",
+    "fn_spell_proto_init":     "eoc::SpellPrototype::Init",
+    "component_data_shift":    None,  # delta, not an address
+}
+
+MSTATE_GOT_SYMBOL = "__ZN2ls11TypeContextINS_23ImmutableDataHeadmasterEE7m_StateE"
 
 IMAGE_BASE = 0x100000000
 
@@ -97,25 +138,59 @@ def _parse_define(source: Path, name: str) -> int:
     return int(m.group(1), 16)
 
 
-def _expected_vas() -> dict[int, tuple[str, str]]:
-    """Map virtual address -> (define name, expected symbol substring)."""
-    vas = {}
-    for rel_path, name, symbol, base_relative in AUDITED_OFFSETS:
+def _parse_table_row(version: str) -> dict[str, int]:
+    """Parse one VersionOffsets struct literal out of offset_table.c."""
+    text = OFFSET_TABLE_C.read_text()
+    block = re.search(
+        rf'\.version\s*=\s*"{re.escape(version)}",(.*?)\n    \}},',
+        text, re.DOTALL,
+    )
+    assert block, f"no {version} row in offset_table.c"
+    fields = {}
+    for m in re.finditer(r"\.(\w+)\s*=\s*(-?0x[0-9a-fA-F]+|\d+)", block.group(1)):
+        fields[m.group(1)] = int(m.group(2), 16 if "0x" in m.group(2) else 10)
+    return fields
+
+
+def _parse_remap_rows() -> list[tuple[int, int]]:
+    """Parse the two-column g_fn_remap table out of offset_table.c."""
+    text = OFFSET_TABLE_C.read_text()
+    block = re.search(
+        r"g_fn_remap\[\]\s*=\s*\{(.*?)\n\};", text, re.DOTALL)
+    assert block, "g_fn_remap not found in offset_table.c"
+    rows = []
+    for m in re.finditer(
+            r"\{\s*(0x[0-9a-fA-F]+)\s*,\s*(0x[0-9a-fA-F]+|0)\s*\}",
+            block.group(1)):
+        rows.append((int(m.group(1), 16), int(m.group(2), 16)))
+    assert rows, "no rows parsed from g_fn_remap"
+    return rows
+
+
+def _all_audited_vas() -> set[int]:
+    vas = set()
+    for rel_path, name, _sym, base_relative in AUDITED_OFFSETS:
         value = _parse_define(REPO_ROOT / rel_path, name)
-        va = value + IMAGE_BASE if base_relative else value
-        vas[va] = (name, symbol)
+        vas.add(value + IMAGE_BASE if base_relative else value)
+    row = _parse_table_row("4.1.1.7209685")
+    for field, sym in TABLE_FIELD_SYMBOLS.items():
+        if sym is not None and row.get(field):
+            vas.add(row[field] + IMAGE_BASE)
+    for _old, new in _parse_remap_rows():
+        if new:
+            vas.add(new)
     return vas
 
 
 @pytest.fixture(scope="module")
-def symbols_at_audited_vas():
+def nm_symbols():
+    """Map VA -> demangled symbols for every audited address (one nm pass)."""
     if not BG3_EXEC.exists():
         pytest.skip("BG3 binary not installed")
     if not (shutil.which("nm") and shutil.which("c++filt")):
         pytest.skip("nm/c++filt unavailable")
 
-    vas = _expected_vas()
-    wanted = {f"{va:016x}" for va in vas}
+    wanted = {f"{va:016x}" for va in _all_audited_vas()}
     nm = subprocess.run(
         ["nm", str(BG3_EXEC)], capture_output=True, text=True, timeout=300
     )
@@ -133,7 +208,21 @@ def symbols_at_audited_vas():
         parts = line.split(maxsplit=2)
         if len(parts) == 3:
             found.setdefault(int(parts[0], 16), []).append(parts[2])
-    return vas, found
+    return found
+
+
+def _assert_symbol_at(found, va, name, symbol):
+    symbols_here = found.get(va, [])
+    assert symbols_here, (
+        f"{name}: no symbol at VA {va:#x} in the installed binary — the game "
+        f"likely updated and this offset is STALE. Re-derive it via: "
+        f"nm <BG3 binary> | c++filt | grep '{symbol}'"
+    )
+    assert any(symbol in s for s in symbols_here), (
+        f"{name}: VA {va:#x} resolves to {symbols_here}, expected a symbol "
+        f"containing '{symbol}' — offset is aimed at the WRONG target. "
+        f"Patching/reading it would corrupt behavior."
+    )
 
 
 @pytest.mark.parametrize(
@@ -141,32 +230,107 @@ def symbols_at_audited_vas():
     AUDITED_OFFSETS,
     ids=[entry[1] for entry in AUDITED_OFFSETS],
 )
-def test_offset_matches_symbol(
-    symbols_at_audited_vas, rel_path, name, symbol, base_relative
-):
-    vas, found = symbols_at_audited_vas
+def test_offset_matches_symbol(nm_symbols, rel_path, name, symbol, base_relative):
     value = _parse_define(REPO_ROOT / rel_path, name)
     va = value + IMAGE_BASE if base_relative else value
+    _assert_symbol_at(nm_symbols, va, name, symbol)
 
-    symbols_here = found.get(va, [])
-    assert symbols_here, (
-        f"{name} = {value:#x}: no symbol at VA {va:#x} in the installed "
-        f"binary — the game likely updated and this offset is STALE. "
-        f"Re-derive it via: nm <BG3 binary> | c++filt | grep '{symbol}'"
+
+@pytest.mark.parametrize(
+    "field",
+    [f for f, s in TABLE_FIELD_SYMBOLS.items() if s is not None],
+)
+def test_offset_table_7209685_row(nm_symbols, field):
+    row = _parse_table_row("4.1.1.7209685")
+    assert field in row, f"{field} missing from 7209685 row"
+    value = row[field]
+    assert value, f"{field} is 0 in the 7209685 row (feature silently disabled)"
+    _assert_symbol_at(
+        nm_symbols, value + IMAGE_BASE,
+        f"offset_table[7209685].{field}", TABLE_FIELD_SYMBOLS[field])
+
+
+def test_offset_table_row_fields_complete():
+    """Every struct field must be classified: either audited or excluded."""
+    header = (REPO_ROOT / "src/core/offset_table.h").read_text()
+    struct = re.search(r"typedef struct \{(.*?)\} VersionOffsets;", header,
+                       re.DOTALL)
+    assert struct
+    declared = set(re.findall(r"u?intptr_t\s+(\w+);", struct.group(1)))
+    declared.discard("version")
+    classified = set(TABLE_FIELD_SYMBOLS)
+    assert declared == classified, (
+        f"offset_table.h fields not classified in TABLE_FIELD_SYMBOLS: "
+        f"{declared - classified or classified - declared} — every new field "
+        f"needs an audit entry or a documented exclusion"
     )
-    assert any(symbol in s for s in symbols_here), (
-        f"{name} = {value:#x}: VA {va:#x} resolves to {symbols_here}, "
-        f"expected a symbol containing '{symbol}' — offset is aimed at the "
-        f"WRONG function. Patching it would corrupt game code."
+
+
+def test_remap_7209685_column(nm_symbols):
+    """Every nonzero 7209685 remap target must be a real symbol."""
+    for old, new in _parse_remap_rows():
+        if new:
+            symbols_here = nm_symbols.get(new, [])
+            assert symbols_here, (
+                f"remap {old:#x} -> {new:#x}: no symbol at target VA — "
+                f"stale remap would call the wrong function"
+            )
+
+
+def test_remap_columns_collision_free():
+    """Either-column matching requires globally unique addresses."""
+    seen: dict[int, int] = {}
+    for i, (old, new) in enumerate(_parse_remap_rows()):
+        for addr in (old, new):
+            if addr == 0:
+                continue
+            assert addr not in seen, (
+                f"address {addr:#x} appears in remap rows {seen[addr]} and "
+                f"{i} — either-column lookup would be ambiguous"
+            )
+            seen[addr] = i
+
+
+def test_mstate_got_slot():
+    """staticdata_mstate_ptr is a __DATA_CONST,__got slot: nm cannot see it.
+    Validate GOT-aware — otool -Iv must map the slot to the
+    TypeContext<ImmutableDataHeadmaster>::m_State symbol."""
+    if not BG3_EXEC.exists():
+        pytest.skip("BG3 binary not installed")
+    if not shutil.which("otool"):
+        pytest.skip("otool unavailable")
+
+    row = _parse_table_row("4.1.1.7209685")
+    va = row["staticdata_mstate_ptr"] + IMAGE_BASE
+    out = subprocess.run(
+        ["otool", "-arch", "arm64", "-Iv", str(BG3_EXEC)],
+        capture_output=True, text=True, timeout=600,
+    )
+    if out.returncode != 0:
+        pytest.skip(f"otool failed: {out.stderr[:200]}")
+    line = next((ln for ln in out.stdout.splitlines()
+                 if ln.startswith(f"0x{va:016x}")), None)
+    assert line, (
+        f"staticdata_mstate_ptr {va:#x}: not an indirect-symbol slot in the "
+        f"installed binary — the __got layout changed; re-derive via "
+        f"otool -Iv | grep m_StateE"
+    )
+    assert MSTATE_GOT_SYMBOL in line, (
+        f"staticdata_mstate_ptr {va:#x} maps to the wrong symbol: {line} — "
+        f"expected {MSTATE_GOT_SYMBOL}. The StaticData traversal would walk "
+        f"garbage."
     )
 
 
 def test_functor_gate_is_independent():
-    """The functor Dobby family is un-auditable by nm (stripped locals), so
-    its install gate must compare against FUNCTOR_ADDRS_VERIFIED_BUILD — the
-    build its addresses came from — never the global version match. This
+    """The functor Dobby family's addresses are nm-auditable, but its ABI is
+    not: the 7209685 Interrupt ExecuteStatsFunctors gained a leading
+    ecs::EntityWorld& parameter. The install gate must therefore compare
+    against FUNCTOR_ADDRS_VERIFIED_BUILD — the build whose addresses AND
+    wrapper signatures were verified — never the global version match. This
     guards against a refactor quietly re-coupling it to BG3_KNOWN_VERSION,
-    which would enable eleven unverified code patches on every version bump.
+    which would enable eleven ABI-unverified code patches on every version
+    bump.
     """
     functor_types = (REPO_ROOT / "src/stats/functor_types.h").read_text()
     m = re.search(
@@ -181,8 +345,23 @@ def test_functor_gate_is_independent():
     )
     assert gate, (
         "main.c functor install gate no longer compares the detected version "
-        "against FUNCTOR_ADDRS_VERIFIED_BUILD — eleven stripped-local code "
+        "against FUNCTOR_ADDRS_VERIFIED_BUILD — eleven ABI-unverified code "
         "patches would install on unverified builds"
     )
     assert "version_detect_matches()) {\n                        if (functor_hooks_init" \
         not in main_c, "functor install re-coupled to global version match"
+
+
+def test_interrupt_remap_stays_disabled_until_wrapper_exists():
+    """The 7209685 Interrupt ExecuteStatsFunctors has a different signature
+    (leading ecs::EntityWorld&). Its remap column must stay 0 until a
+    dedicated wrapper for the new ABI lands in functor_hooks.c."""
+    rows = _parse_remap_rows()
+    interrupt = [new for old, new in rows if old == 0x1057965E4]
+    assert interrupt, "Interrupt row (0x1057965e4) missing from g_fn_remap"
+    if interrupt[0] != 0:
+        wrappers = (REPO_ROOT / "src/stats/functor_hooks.c").read_text()
+        assert "EntityWorld" in wrappers, (
+            "Interrupt remap target enabled but functor_hooks.c has no "
+            "EntityWorld-aware wrapper — the hook would be ABI-mismatched"
+        )

--- a/tests/harness/test_offset_audit.py
+++ b/tests/harness/test_offset_audit.py
@@ -124,6 +124,8 @@ TABLE_FIELD_SYMBOLS = {
     "fn_storage_tryget":       "ecs::EntityStorageContainer::TryGet",
     "fn_spell_proto_init":     "eoc::SpellPrototype::Init",
     "component_data_shift":    None,  # delta, not an address
+    "osiris_interface_ptr":    None,  # no symbol — disasm-audited, see
+                                      # test_osiris_interface_slot_matches_disasm
 }
 
 MSTATE_GOT_SYMBOL = "__ZN2ls11TypeContextINS_23ImmutableDataHeadmasterEE7m_StateE"
@@ -319,6 +321,57 @@ def test_mstate_got_slot():
         f"staticdata_mstate_ptr {va:#x} maps to the wrong symbol: {line} — "
         f"expected {MSTATE_GOT_SYMBOL}. The StaticData traversal would walk "
         f"garbage."
+    )
+
+
+OSIRIS_QUERY_MANGLED = "__ZN3osi15OsirisInterface11OsirisQueryEjP16COsiArgumentDesc"
+
+
+def test_osiris_interface_slot_matches_disasm():
+    """osiris_interface_ptr (the osi::OsirisInterface global instance slot,
+    used by osi_read_param_defs in main.c) has no nm symbol. Its authoritative
+    reference is OsirisQuery's own load of the global — the first
+    ``adrp xN, <page>`` / ``ldr xM, [xN, #off]`` pair in the function prologue
+    after the stack-guard load. Disassemble it and require the computed target
+    to equal the table value (2026-07-29 on 7209685: adrp 0x108a86000 +
+    ldr #0x128 -> 0x108a86128)."""
+    if not BG3_EXEC.exists():
+        pytest.skip("BG3 binary not installed")
+    if not shutil.which("otool"):
+        pytest.skip("otool unavailable")
+
+    row = _parse_table_row("4.1.1.7209685")
+    expected = row["osiris_interface_ptr"] + IMAGE_BASE
+    out = subprocess.run(
+        ["otool", "-arch", "arm64", "-tV", "-p", OSIRIS_QUERY_MANGLED,
+         str(BG3_EXEC)],
+        capture_output=True, text=True, timeout=600,
+    )
+    if out.returncode != 0:
+        pytest.skip(f"otool failed: {out.stderr[:200]}")
+    lines = out.stdout.splitlines()[:40]
+    assert any(OSIRIS_QUERY_MANGLED in ln for ln in lines), (
+        "osi::OsirisInterface::OsirisQuery symbol not found — signature "
+        "changed in a game update; re-derive the instance slot"
+    )
+    targets = []
+    page = None
+    page_reg = None
+    for ln in lines:
+        m = re.search(r"adrp\s+(x\d+),\s+\S+\s+;\s+0x([0-9a-f]+)", ln)
+        if m:
+            page_reg, page = m.group(1), int(m.group(2), 16)
+            continue
+        m = re.search(r"ldr\s+x\d+,\s+\[(x\d+)(?:,\s+#0x([0-9a-f]+))?\]", ln)
+        if m and page is not None and m.group(1) == page_reg:
+            off = int(m.group(2), 16) if m.group(2) else 0
+            targets.append(page + off)
+            page = page_reg = None
+    assert expected in targets, (
+        f"osiris_interface_ptr {expected:#x} not among OsirisQuery's "
+        f"adrp+ldr targets {[hex(t) for t in targets]} — the instance slot "
+        f"moved in a game update; osi_read_param_defs would read garbage. "
+        f"Re-derive from the disasm and update offset_table.c."
     )
 
 

--- a/tools/bg3se_harness/cli.py
+++ b/tools/bg3se_harness/cli.py
@@ -158,12 +158,16 @@ def _launch_until_socket(
             dismiss_splash=True,
             process=session.direct_process,
             tracker=session.tracker,
+            require_session=bool(continue_game or load_save),
         )
         health["pid"] = session.pid
         health["attempt"] = attempt
         attempts.append(health)
 
-        if health.get("socket_connected"):
+        boot_ok = health.get("socket_connected") and (
+            not (continue_game or load_save) or health.get("session_loaded")
+        )
+        if boot_ok:
             return session, health, attempts
 
         retryable = launch_mod.should_retry_boot(health)

--- a/tools/bg3se_harness/launch.py
+++ b/tools/bg3se_harness/launch.py
@@ -996,6 +996,11 @@ def launch(continue_game=False, load_save=None, extra_flags=None,
         stderr=subprocess.DEVNULL,
         start_new_session=True,
         env=env,
+        # SteamAPI_RestartAppIfNecessary looks for steam_appid.txt in the CWD.
+        # Running from the binary's directory suppresses the exit-0 bounce +
+        # Steam relaunch — which would strip every BG3SE_* env var above and
+        # leave video-skip/splash-dismiss dormant in the adopted process.
+        cwd=str(BG3_EXEC.parent),
     )
     proc.bg3se_headless_graphics = headless_graphics
     tracker.set_direct_process(proc.pid)

--- a/tools/bg3se_harness/launch.py
+++ b/tools/bg3se_harness/launch.py
@@ -1031,7 +1031,16 @@ _MENU_STALL_FIRST_ACTION_S = 20.0
 _MENU_STALL_RETRY_INTERVAL_S = 12.0
 _MENU_STALL_MAX_ACTIONS = 6
 _MENU_STALL_ABORT_S = 120.0
-BOOT_RETRYABLE_STAGES = {"timeout", "menu_stalled"}
+# Extra budget granted once the socket responds but a session is still
+# required (require_session=True): Continue click + level load can take
+# well over the plain socket timeout.
+_SESSION_LOAD_GRACE_S = 240.0
+# !identity game_state values that mean a save is actually loaded.
+_SESSION_LOADED_STATES = {"Running", "Paused"}
+# game_state values during which menu/modal clicking is still safe.
+# Once the state leaves this set the game is loading — hands off the mouse.
+_MENU_SAFE_STATES = {None, "Unknown", "Uninitialized", "Init"}
+BOOT_RETRYABLE_STAGES = {"timeout", "menu_stalled", "session_timeout"}
 _CONTINUE_CLICK_FRACTIONS = [
     # Measured from .screenshots/boot-stall-1778937630.png after watching
     # the cursor land right/below the button. Fractions are relative to the
@@ -1072,9 +1081,70 @@ def _watchdog_target_for_attempt(attempt):
     return _WATCHDOG_CLICK_SEQUENCE[index]
 
 
+# Standard macOS title bar height in points. The watchdog fractions are
+# measured against the full System Events window bounds (title bar included);
+# the in-process !click command takes fractions of the LSMTLView content
+# bounds, which exclude it in windowed mode.
+_TITLE_BAR_PT = 28.0
+
+
+def _window_to_view_fractions(xf, yf, win_h):
+    """Convert full-window fractions to LSMTLView content-bounds fractions."""
+    if not win_h or win_h <= _TITLE_BAR_PT * 2:
+        return xf, yf
+    content_h = win_h - _TITLE_BAR_PT
+    view_yf = (yf * win_h - _TITLE_BAR_PT) / content_h
+    return xf, min(max(view_yf, 0.0), 1.0)
+
+
+def _socket_command(cmd, timeout=2.0):
+    """Send one console command over the SE socket; return reply text or None."""
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        sock.connect(SOCKET_PATH)
+        try:
+            sock.recv(4096)
+        except socket.timeout:
+            pass
+        sock.sendall((cmd + "\n").encode())
+        time.sleep(0.2)
+        data = b""
+        try:
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+        except socket.timeout:
+            pass
+        sock.close()
+        return data.decode("utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _socket_click(xf_window, yf_window, win_h):
+    """In-process click via !click (no cursor move, no focus). None if socket down."""
+    vxf, vyf = _window_to_view_fractions(xf_window, yf_window, win_h)
+    resp = _socket_command(f"!click {vxf:.4f} {vyf:.4f}")
+    if resp is None:
+        return None
+    return {"success": "click posted" in resp, "view_fraction": {"x": round(vxf, 4), "y": round(vyf, 4)},
+            "method": "in_process_click", "response": resp.strip()[:200]}
+
+
 def wait_for_socket(timeout=HEALTH_TIMEOUT, dismiss_splash=False, process=None,
-                    tracker=None):
+                    tracker=None, require_session=False):
     """Wait for the SE socket to respond to Lua commands.
+
+    When require_session is True (a --continue/--save launch), a responsive
+    socket is NOT success: the console answers !identity from the main menu
+    while game_state is still "Init". The loop keeps running — and keeps the
+    menu/mod-verification watchdog alive — until identity reports game_state
+    Running/Paused, granting itself _SESSION_LOAD_GRACE_S beyond the socket
+    timeout. Watchdog clicks stop the moment game_state leaves the menu-safe
+    set, so nothing touches the UI during a level load.
 
     When dismiss_splash is True, periodically sends Escape+Space via
     System Events key code to dismiss the BG3 splash screen while waiting.
@@ -1105,6 +1175,9 @@ def wait_for_socket(timeout=HEALTH_TIMEOUT, dismiss_splash=False, process=None,
     socket_listening_at = None
     menu_watchdog_actions = []
     phases = []
+    socket_first_responded = False
+    session_wait_extended = False
+    last_game_state = None
 
     def _phase(name, detail=""):
         elapsed = time.monotonic() - start
@@ -1203,6 +1276,7 @@ def wait_for_socket(timeout=HEALTH_TIMEOUT, dismiss_splash=False, process=None,
             should_act = (
                 dismiss_splash
                 and bg3_pid
+                and last_game_state in _MENU_SAFE_STATES
                 and stalled_for >= _MENU_STALL_FIRST_ACTION_S
                 and len(menu_watchdog_actions) < _MENU_STALL_MAX_ACTIONS
                 and (
@@ -1226,13 +1300,15 @@ def wait_for_socket(timeout=HEALTH_TIMEOUT, dismiss_splash=False, process=None,
             if (
                 dismiss_splash
                 and socket_ever_connected
+                and last_game_state in _MENU_SAFE_STATES
                 and len(menu_watchdog_actions) >= _MENU_STALL_MAX_ACTIONS
                 and stalled_for >= _MENU_STALL_ABORT_S
             ):
                 elapsed_ms = int((time.monotonic() - start) * 1000)
                 _phase("menu_stalled", f"{elapsed_ms}ms")
                 return {
-                    "socket_connected": False,
+                    "socket_connected": socket_first_responded,
+                    "session_loaded": False,
                     "stage": "menu_stalled",
                     "elapsed_ms": elapsed_ms,
                     "dismiss_attempts": dismiss_count,
@@ -1252,6 +1328,10 @@ def wait_for_socket(timeout=HEALTH_TIMEOUT, dismiss_splash=False, process=None,
                 if found:
                     menu_detected = True
                     _phase("menu_detected", f"buttons={buttons}")
+                    # Menu visible — stop the in-process Escape/Space loop
+                    # before it can fight menu clicks (Escape reopens/closes
+                    # menu overlays).
+                    _socket_command("!splash_done")
 
         if menu_detected and not continue_sent:
             # In-process CGEventPostToPid/NSApp sendEvent can't reach
@@ -1335,9 +1415,11 @@ def wait_for_socket(timeout=HEALTH_TIMEOUT, dismiss_splash=False, process=None,
                 text = re.sub(rb'\033\[[0-9;]*m', b'', response).decode(
                     "utf-8", errors="replace").strip()
                 elapsed_ms = int((time.monotonic() - start) * 1000)
-                _phase("socket_responded", f"{elapsed_ms}ms")
-                if tracker:
-                    tracker.set_socket_ready()
+                if not socket_first_responded:
+                    socket_first_responded = True
+                    _phase("socket_responded", f"{elapsed_ms}ms")
+                    if tracker:
+                        tracker.set_socket_ready()
                 result = {
                     "socket_connected": True,
                     "se_version": text if text else "connected",
@@ -1350,7 +1432,24 @@ def wait_for_socket(timeout=HEALTH_TIMEOUT, dismiss_splash=False, process=None,
                     result["identity_pid"] = identity_pid
                 if peer_pid is not None:
                     result["peer_pid"] = peer_pid
-                return result
+                if menu_watchdog_actions:
+                    result["watchdog_actions"] = menu_watchdog_actions
+
+                if not require_session:
+                    return result
+
+                last_game_state = (identity or {}).get("game_state")
+                if last_game_state in _SESSION_LOADED_STATES:
+                    _phase("session_loaded", f"game_state={last_game_state}")
+                    result["session_loaded"] = True
+                    return result
+
+                if not session_wait_extended:
+                    session_wait_extended = True
+                    timeout = max(timeout, elapsed + _SESSION_LOAD_GRACE_S)
+                    _phase("session_waiting",
+                           f"game_state={last_game_state}, "
+                           f"grace={_SESSION_LOAD_GRACE_S:.0f}s")
 
         except (ConnectionRefusedError, FileNotFoundError, OSError):
             pass
@@ -1362,9 +1461,13 @@ def wait_for_socket(timeout=HEALTH_TIMEOUT, dismiss_splash=False, process=None,
     if tracker and tracker.phase == "waiting_for_steam_relaunch":
         stage = "steam_relaunch_timeout"
         tracker.set_failed("steam_relaunch_timeout")
-    _phase(stage, f"{elapsed_ms}ms")
+    elif require_session and socket_first_responded:
+        stage = "session_timeout"
+    _phase(stage, f"{elapsed_ms}ms, game_state={last_game_state}")
     return {
-        "socket_connected": False,
+        "socket_connected": socket_first_responded,
+        "session_loaded": False,
+        "last_game_state": last_game_state,
         "stage": stage,
         "elapsed_ms": elapsed_ms,
         "dismiss_attempts": dismiss_count,
@@ -1543,61 +1646,71 @@ def _collect_boot_diagnostics():
 
 def should_retry_boot(health):
     """Return True when a failed boot is likely transient/retryable."""
-    if health.get("socket_connected"):
+    if health.get("socket_connected") and health.get("session_loaded", True):
         return False
     return health.get("stage") in BOOT_RETRYABLE_STAGES
 
 
 def _try_watchdog_continue(pid, attempt):
-    """Retry menu progress with a measured foreground mouse click."""
+    """Retry menu progress with in-process socket clicks (no cursor movement).
+
+    Prefers !click over the SE socket — synthetic [LSMTLView mouseDown:]
+    events that need no focus, no activation, and never move the physical
+    cursor. OCR-derived button centers beat the hardcoded fractions when
+    available. Falls back to a foreground physical click only when the
+    socket is unreachable.
+    """
     action = {
         "attempt": attempt,
-        "method": "foreground_physical_left_click",
+        "method": "in_process_click",
         "success": False,
     }
     try:
         from .menu import click_fraction, detect_menu
 
         detection = detect_menu()
-        buttons = [b.get("text") for b in detection.get("buttons", [])]
-        action["buttons"] = buttons
+        buttons = {b.get("text"): b for b in detection.get("buttons", [])}
+        action["buttons"] = list(buttons)
         action["menu_detected"] = bool({"Continue", "New Game", "Load Game", "Multiplayer"} & set(buttons))
         action["ocr_error"] = detection.get("error")
+        window = detection.get("window") or {}
+        win_h = window.get("height")
+
+        # The dismisser has done its job once we can see any UI to click.
+        _socket_command("!splash_done")
+
         purpose, fraction = _watchdog_target_for_attempt(attempt)
         if action["menu_detected"] and purpose == "dismiss_splash":
             purpose = "click_continue"
             fraction = _CONTINUE_CLICK_FRACTIONS[0]
-        action["purpose"] = purpose
 
+        # Prefer the OCR-measured Continue position over the constants.
+        target_btn = buttons.get("Continue") if purpose == "click_continue" else None
+        if target_btn and window.get("width") and win_h:
+            fraction = {
+                "x": (target_btn["screen_x"] - window.get("x", 0)) / window["width"],
+                "y": (target_btn["screen_y"] - window.get("y", 0)) / win_h,
+                "label": "continue_button_ocr",
+            }
+        action["purpose"] = purpose
         action["target_fraction"] = fraction
 
-        if isinstance(fraction, list):
-            clicks = []
-            geometry = detection.get("geometry")
-            for item in fraction:
+        targets = fraction if isinstance(fraction, list) else [fraction]
+        clicks = []
+        for item in targets:
+            click_result = _socket_click(item["x"], item["y"], win_h)
+            if click_result is None:
+                # Socket down — last resort: physical foreground click.
                 click_result = click_fraction(
-                    item["x"],
-                    item["y"],
-                    method="both",
-                    activate=True,
+                    item["x"], item["y"], method="both", activate=True,
                 )
-                click_result["target_fraction"] = item
-                clicks.append(click_result)
-                geometry = click_result.get("geometry") or geometry
-                time.sleep(0.25)
-            action["clicks"] = clicks
-            action["geometry"] = geometry
-            action["success"] = any(bool(c.get("success")) for c in clicks)
-        else:
-            click_result = click_fraction(
-                fraction["x"],
-                fraction["y"],
-                method="both",
-                activate=True,
-            )
-            action["click"] = click_result
-            action["geometry"] = click_result.get("geometry") or detection.get("geometry")
-            action["success"] = bool(click_result.get("success"))
+                click_result["method"] = "foreground_physical_left_click"
+            click_result["target_fraction"] = item
+            clicks.append(click_result)
+            time.sleep(0.25)
+        action["clicks"] = clicks
+        action["geometry"] = detection.get("geometry")
+        action["success"] = any(bool(c.get("success")) for c in clicks)
     except Exception as exc:
         action["error"] = str(exc)
     return action
@@ -1633,11 +1746,15 @@ def _try_dismiss_splash(attempt, pid=None):
 
 
 def _try_click_continue(pid):
-    """Send Enter to click the highlighted Continue button."""
+    """Send Enter to activate the focused Continue button (in-process first)."""
+    resp = _socket_command(f"!key {_kVK_Return}")
+    if resp is not None:
+        print("Sent Enter to click Continue (in-process)", file=sys.stderr)
+        return
     try:
         from .menu import cg_key_to_pid
         cg_key_to_pid(pid, _kVK_Return)
-        print("Sent Enter to click Continue", file=sys.stderr)
+        print("Sent Enter to click Continue (SystemEvents fallback)", file=sys.stderr)
     except Exception:
         pass
 

--- a/tools/bg3se_harness/menu.py
+++ b/tools/bg3se_harness/menu.py
@@ -160,33 +160,32 @@ def _normalise_click_result(result, method):
 
 
 def activate_bg3():
-    """Bring BG3 to the foreground for input probes."""
-    script = (
-        'tell application "Baldur\'s Gate 3" to activate\n'
-        'tell application "System Events"\n'
-        '  if exists process "Baldur\'s Gate 3" then\n'
-        '    set frontmost of process "Baldur\'s Gate 3" to true\n'
-        '    return "ok"\n'
-        '  else\n'
-        '    return "no_process"\n'
-        '  end if\n'
-        'end tell'
-    )
+    """Bring an already-running BG3 to the foreground for input probes.
+
+    Activates by PID via NSRunningApplication. Never uses
+    `tell application ... to activate` — LaunchServices treats that as a
+    launch request when the app is not running, which spawned fresh BG3
+    instances (Steam bounce pairs) mid-automation whenever the tracked
+    process had died.
+    """
+    pid = _get_bg3_pid()
+    if not pid:
+        return {"success": False, "method": "nsrunningapplication",
+                "error": "BG3 not running"}
     try:
-        r = subprocess.run(
-            ["osascript", "-e", script],
-            capture_output=True, text=True, timeout=5,
+        from AppKit import (
+            NSRunningApplication,
+            NSApplicationActivateIgnoringOtherApps,
         )
-        if r.returncode == 0 and "ok" in r.stdout:
-            return {"success": True, "method": "activate_and_frontmost"}
-        return {
-            "success": False,
-            "method": "activate_and_frontmost",
-            "error": r.stderr.strip() or r.stdout.strip(),
-            "returncode": r.returncode,
-        }
-    except (subprocess.TimeoutExpired, OSError) as exc:
-        return {"success": False, "method": "activate_and_frontmost", "error": str(exc)}
+        app = NSRunningApplication.runningApplicationWithProcessIdentifier_(pid)
+        if app is None:
+            return {"success": False, "method": "nsrunningapplication",
+                    "pid": pid, "error": f"no running application for pid {pid}"}
+        ok = bool(app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps))
+        return {"success": ok, "method": "nsrunningapplication", "pid": pid}
+    except Exception as exc:
+        return {"success": False, "method": "nsrunningapplication",
+                "pid": pid, "error": str(exc)}
 
 
 def cg_key(keycode):

--- a/tools/offset_manifest.json
+++ b/tools/offset_manifest.json
@@ -1,0 +1,97 @@
+{
+  "_about": [
+    "Recipe for porting BG3SE-macOS address tables to a new game version.",
+    "Every per-version address the code needs is listed here with how to resolve it.",
+    "The macOS BG3 binary keeps its symbol table, so most entries resolve via `nm`.",
+    "Run: PYTHONPATH=tools python3 -m tools.port_offsets resolve   (see docs/PORTING.md)",
+    "",
+    "Resolution methods:",
+    "  symbol      -> nm the demangled `symbol`; the address IS the result.",
+    "  data_shift  -> not exported; result = (baseline_ghidra + data_shift), where",
+    "                 data_shift is derived once from `data_shift_anchor` below.",
+    "  constant    -> a __TEXT/data address that does NOT change between versions",
+    "                 (verify it still resolves to the same symbol; warn if not).",
+    "  struct_offset -> a field offset WITHIN an object. Stable across minor patches.",
+    "                 Carried as-is; only changes if Larian restructures the class",
+    "                 (then it needs Ghidra/runtime re-discovery -- the tool flags it).",
+    "All `baseline` values are full Ghidra addresses for 4.1.1.6995620 (the verified base)."
+  ],
+
+  "baseline_version": "4.1.1.6995620",
+
+  "data_shift_anchor": {
+    "_note": "Derives the uniform __DATA shift = nm(symbol) - baseline. For 7209685 this is +0x8000. Pick an exported global whose 6995620 address is known.",
+    "symbol": "ls::TypeId<eoc::FeatManager, ls::ImmutableDataHeadmaster>::m_TypeIndex",
+    "baseline": "0x1088efd00"
+  },
+
+  "offset_table_functions": [
+    {"field": "fn_feat_getfeats",      "baseline": "0x101b752b4", "symbol": "eoc::FeatManager::GetFeats() const"},
+    {"field": "fn_getallfeats",        "baseline": "0x10120b3e8", "symbol": "eoc::character_creation::GetAllFeats(eoc::character_creation::Environment const&)"},
+    {"field": "fn_get_background",     "baseline": "0x102994834", "symbol": "eoc::BackgroundManager const* ls::ImmutableDataHeadmaster::Get<eoc::BackgroundManager>() const"},
+    {"field": "fn_get_origin",         "baseline": "0x10341c42c", "symbol": "eoc::OriginManager const* ls::ImmutableDataHeadmaster::Get<eoc::OriginManager>() const"},
+    {"field": "fn_get_class",          "baseline": "0x10262f184", "symbol": "eoc::ClassDescriptions const* ls::ImmutableDataHeadmaster::Get<eoc::ClassDescriptions>() const"},
+    {"field": "fn_get_progression",    "baseline": "0x103697f0c", "symbol": "eoc::ProgressionManager const* ls::ImmutableDataHeadmaster::Get<eoc::ProgressionManager>() const"},
+    {"field": "fn_get_actionresource", "baseline": "0x1011a4494", "symbol": "eoc::ActionResourceTypes const* ls::ImmutableDataHeadmaster::Get<eoc::ActionResourceTypes>() const"},
+    {"field": "fn_get_template_raw",   "baseline": "0x105f96304", "symbol": "ls::GlobalTemplateManager::GetTemplateRaw(ls::FixedString const&) const"},
+    {"field": "fn_cache_template",     "baseline": "0x105d31ce4", "symbol": "ls::CacheTemplateManagerBase::CacheTemplate(ls::GameObjectTemplate const*, ls::FixedString const&, ls::FixedString const&)"},
+    {"field": "fn_try_get_uuid_mapping","baseline": "0x1010dc924", "symbol": "ls::Result<ecs::_private::EntityViewFinder<ecs::_private::QueryViewFinder<ecs::query::alive::Spec<ls::TypeList<ls::uuid::ToHandleMappingComponent const>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ecs::QueryTypePersistentTag, ecs::QueryTypeAliveTag>>::type>::type, ls::Error> ecs::legacy::Helper::TryGetSingleton<ecs::query::alive::Spec<ls::TypeList<ls::uuid::ToHandleMappingComponent const>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ecs::QueryTypePersistentTag, ecs::QueryTypeAliveTag>>(ecs::EntityWorld&)"},
+    {"field": "fn_storage_tryget",     "baseline": "0x10636b27c", "symbol": "ecs::EntityStorageContainer::TryGet(ls::ID<ecs::EntityHandleTraits>)"},
+    {"field": "fn_spell_proto_init",   "baseline": "0x101f72754", "symbol": "eoc::SpellPrototype::Init(ls::FixedString const&)"}
+  ],
+
+  "remap_functions": [
+    {"name": "FixedString::Create",        "baseline": "0x1064b9ebc", "symbol": "ls::FixedString::Create(char const*, int)"},
+    {"name": "ResourceContainer::GetResource","baseline": "0x1060cc608", "symbol": "ls::ResourceContainer::GetResource(ls::EResourceType, ls::FixedString const&) const"},
+    {"name": "ExecuteStatsFunctor",        "baseline": "0x105783a38", "symbol": "ExecuteStatsFunctor(eoc::StatsFunctorBase const*, unsigned long, esv::functor::AttackTargetContextData&)"},
+    {"name": "ExecuteFunctors<AttackTarget>","baseline": "0x105787918", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::AttackTargetContextData&)"},
+    {"name": "ExecuteFunctors<AttackPosition>","baseline": "0x105787c6c","symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::AttackPositionContextData&)"},
+    {"name": "ExecuteFunctors<Move>",      "baseline": "0x10578975c", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::MoveContextData&)"},
+    {"name": "ExecuteFunctors<Target>",    "baseline": "0x10578a918", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::TargetContextData&)"},
+    {"name": "ExecuteFunctors<NearbyAttacked>","baseline": "0x10578e4d8","symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::NearbyAttackedContextData&)"},
+    {"name": "ExecuteFunctors<NearbyAttacking>","baseline": "0x10578fba8","symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::NearbyAttackingContextData&)"},
+    {"name": "ExecuteFunctors<Equip>",     "baseline": "0x105790a28", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::EquipContextData&)"},
+    {"name": "ExecuteFunctors<Source>",    "baseline": "0x105792a90", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::SourceContextData&)"},
+    {"name": "ExecuteFunctors<Interrupt>", "baseline": "0x1057965e4", "symbol": "esv::functor::ExecuteStatsFunctors(ecs::EntityWorld&, eoc::StatsFunctorList const*, esv::functor::InterruptContextData&)"},
+    {"name": "TranslatedStringRepository::TryGet","baseline": "0x106534d54","symbol": "ls::TranslatedStringRepository::TryGet(ls::RuntimeStringHandle const&, ls::identity::EIdentity, ls::identity::EIdentity) const"},
+    {"name": "TranslatedStringRepository::Get","baseline": "0x106535148","symbol": "ls::TranslatedStringRepository::Get(ls::RuntimeStringHandle const&, ls::identity::EIdentity, ls::identity::EIdentity) const"},
+    {"name": "TranslatedStringRepository::AddTranslatedString","baseline": "0x106532590","symbol": "ls::TranslatedStringRepository::AddTranslatedString(ls::RuntimeStringHandle, ls::_StringView<char>, ls::TranslatedMapRepo<ls::RuntimeStringNoVersionHashOps>*, ls::EnumFlags<ls::EAddFlags>)"},
+    {"name": "MessageFactory::GetFreeMessage","baseline": "0x1063d5998","symbol": "net::MessageFactory::GetFreeMessage(int)"},
+    {"name": "STDString::STDString(char const*)","baseline": "0x10651fb60","symbol": "ls::STDString::STDString(char const*)"}
+  ],
+
+  "constant_functions": [
+    {"name": "BinkManager::LoadVideo", "baseline": "0x10390b6cc", "symbol": "bik::BinkManager::LoadVideo(ls::Path const&)", "_note": "unchanged 6995620 -> 7209685; verify it still maps to this symbol"}
+  ],
+
+  "_data_singletons_note": "baseline = offset from binary base (the value stored in offset_table.c, i.e. Ghidra addr - 0x100000000). result = baseline + data_shift.",
+  "data_singletons": [
+    {"field": "eocserver_ptr",           "baseline": "0x0898e8b8", "method": "data_shift", "note": "esv::EocServer::m_ptr (not exported)"},
+    {"field": "eocclient_ptr",           "baseline": "0x0898c968", "method": "data_shift", "note": "ecl::EocClient::m_ptr (not exported)"},
+    {"field": "spell_proto_mgr_ptr",     "baseline": "0x089bac80", "method": "data_shift", "note": "SpellPrototypeManager::m_ptr (not exported)"},
+    {"field": "rpgstats_ptr",            "baseline": "0x089c5730", "method": "data_shift", "note": "RPGStats::m_ptr (not exported)"},
+    {"field": "resource_mgr_ptr",        "baseline": "0x08a8f070", "method": "data_shift", "note": "ResourceManager::m_ptr (not exported)"},
+    {"field": "level_mgr_ptr",           "baseline": "0x08a3be40", "method": "data_shift", "note": "LevelManager::m_ptr (not exported)"},
+    {"field": "global_template_mgr_ptr", "baseline": "0x08a88508", "method": "data_shift", "note": "ls::GlobalTemplateManager::m_ptr (not exported)"},
+    {"field": "cache_template_mgr_ptr",  "baseline": "0x08a309a8", "method": "data_shift", "note": "CacheTemplateManager::m_ptr (not exported)"},
+    {"field": "level_cache_mgr_ptr",     "baseline": "0x08a735d8", "method": "data_shift", "note": "Level::s_CacheTemplateManager (not exported)"},
+    {"field": "staticdata_mstate_ptr",   "baseline": "0x083c4a68", "method": "data_shift", "note": "PTR to ImmutableDataHeadmaster TypeContext m_State (not exported)"},
+    {"field": "gst_ptr",                 "baseline": "0x08aeccd8", "method": "data_shift", "note": "ls::gGlobalStringTable subtable base ptr (verify via ls::gst::Get disasm)"}
+  ],
+
+  "exported_data": [
+    {"name": "TranslatedStringRepository::m_ptr", "baseline": "0x108aed088", "symbol": "ls::TranslatedStringRepository::m_ptr", "consumer": "localization.c LOCA_REPO_OFFSET", "_note": "exported 'b' symbol; also equals data_shift result -- good cross-check"}
+  ],
+
+  "struct_offsets": [
+    {"name": "EocServer -> EntityWorld",          "value": "0x288",  "where": "entity_system.c OFFSET_ENTITYWORLD_IN_EOCSERVER", "verify_via": "esv::EocServer::StartUp disasm: ldr xN,[this,#0x288]"},
+    {"name": "EntityWorld -> StorageContainer",   "value": "0x2d0",  "where": "component_templates.h ENTITYWORLD_STORAGE_OFFSET"},
+    {"name": "EntityWorld -> ImmediateWorldCache","value": "0x3f0",  "where": "component_templates.h ENTITYWORLD_CACHE_OFFSET"},
+    {"name": "RPGStats -> FixedStrings pool",     "value": "0x348",  "where": "ghidra/offsets/STATS.md"},
+    {"name": "RefMap capacity",                   "value": "0x10",   "where": "prototype_managers.c REFMAP_OFFSET_CAPACITY"},
+    {"name": "RefMap keys array",                 "value": "0x28",   "where": "prototype_managers.c REFMAP_OFFSET_KEYS"},
+    {"name": "RefMap values array",               "value": "0x38",   "where": "prototype_managers.c REFMAP_OFFSET_VALUES"},
+    {"name": "Stat object -> name FixedString",   "value": "0x20",   "where": "stats_manager.c STATS_OBJECT_OFFSET_NAME"},
+    {"name": "GST subtable stride",               "value": "0x1200", "where": "fixed_string.c (ls::gst::Get: umaddl ... #0x1200)"}
+  ]
+}

--- a/tools/offset_manifest.json
+++ b/tools/offset_manifest.json
@@ -7,22 +7,40 @@
     "",
     "Resolution methods:",
     "  symbol      -> nm the demangled `symbol`; the address IS the result.",
-    "  data_shift  -> not exported; result = (baseline_ghidra + data_shift), where",
+    "                 Plain `nm` (no -gU) also lists LOCAL symbols -- nearly every",
+    "                 'not exported' global is in fact nm-resolvable this way.",
+    "  got         -> the address is a __DATA_CONST,__got SLOT (contents = the",
+    "                 symbol's address). nm cannot see it; resolve via",
+    "                 `otool -arch arm64 -Iv` and match the slot mapped to `symbol`.",
+    "  disasm      -> anonymous slot with no symbol at all (e.g. __common bss).",
+    "                 Must be re-derived by disassembly (ADRP+LDR reference scan);",
+    "                 the tool flags it MANUAL. Do NOT assume it follows data_shift:",
+    "                 global_switches_ptr moved -0x24000 between 6995620 and 7209685",
+    "                 while its neighbors moved +0x8000.",
+    "  data_shift  -> LAST RESORT: result = (baseline_ghidra + data_shift), where",
     "                 data_shift is derived once from `data_shift_anchor` below.",
+    "                 Only sound for TypeId globals proven to shift uniformly.",
     "  constant    -> a __TEXT/data address that does NOT change between versions",
     "                 (verify it still resolves to the same symbol; warn if not).",
     "  struct_offset -> a field offset WITHIN an object. Stable across minor patches.",
     "                 Carried as-is; only changes if Larian restructures the class",
     "                 (then it needs Ghidra/runtime re-discovery -- the tool flags it).",
-    "All `baseline` values are full Ghidra addresses for 4.1.1.6995620 (the verified base)."
+    "VINTAGE: `baseline` values on remap_functions are 4.1.1.6995620 (remap column 0).",
+    "The COMPILED-IN constants in the C sources are 4.1.1.7209685 vintage, and",
+    "component_data_shift is the signed delta FROM 7209685 TO the target version,",
+    "so the anchor baseline below is the 7209685 address.",
+    "ABI WARNING: symbol resolution proves an address, never a signature. Diff the",
+    "demangled signature against the wrapper in the C code before enabling a hook",
+    "(the 7209685 Interrupt ExecuteStatsFunctors gained a leading ecs::EntityWorld&)."
   ],
 
   "baseline_version": "4.1.1.6995620",
+  "constants_vintage": "4.1.1.7209685",
 
   "data_shift_anchor": {
-    "_note": "Derives the uniform __DATA shift = nm(symbol) - baseline. For 7209685 this is +0x8000. Pick an exported global whose 6995620 address is known.",
+    "_note": "Derives component_data_shift = nm(symbol) - baseline, the signed delta from the 7209685-vintage compiled-in TypeId constants to the target version. 0 on 7209685 itself; -0x8000 on 6995620.",
     "symbol": "ls::TypeId<eoc::FeatManager, ls::ImmutableDataHeadmaster>::m_TypeIndex",
-    "baseline": "0x1088efd00"
+    "baseline": "0x1088f7d00"
   },
 
   "offset_table_functions": [
@@ -52,7 +70,7 @@
     {"name": "ExecuteFunctors<NearbyAttacking>","baseline": "0x10578fba8","symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::NearbyAttackingContextData&)"},
     {"name": "ExecuteFunctors<Equip>",     "baseline": "0x105790a28", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::EquipContextData&)"},
     {"name": "ExecuteFunctors<Source>",    "baseline": "0x105792a90", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::SourceContextData&)"},
-    {"name": "ExecuteFunctors<Interrupt>", "baseline": "0x1057965e4", "symbol": "esv::functor::ExecuteStatsFunctors(ecs::EntityWorld&, eoc::StatsFunctorList const*, esv::functor::InterruptContextData&)"},
+    {"name": "ExecuteFunctors<Interrupt>", "baseline": "0x1057965e4", "symbol": "esv::functor::ExecuteStatsFunctors(ecs::EntityWorld&, eoc::StatsFunctorList const*, esv::functor::InterruptContextData&)", "abi_changed": true, "_note": "the 6995620 variant had NO EntityWorld& param -- the existing wrapper ABI does not fit. Emit 0 in the remap column until functor_hooks.c grows an EntityWorld-aware wrapper."},
     {"name": "TranslatedStringRepository::TryGet","baseline": "0x106534d54","symbol": "ls::TranslatedStringRepository::TryGet(ls::RuntimeStringHandle const&, ls::identity::EIdentity, ls::identity::EIdentity) const"},
     {"name": "TranslatedStringRepository::Get","baseline": "0x106535148","symbol": "ls::TranslatedStringRepository::Get(ls::RuntimeStringHandle const&, ls::identity::EIdentity, ls::identity::EIdentity) const"},
     {"name": "TranslatedStringRepository::AddTranslatedString","baseline": "0x106532590","symbol": "ls::TranslatedStringRepository::AddTranslatedString(ls::RuntimeStringHandle, ls::_StringView<char>, ls::TranslatedMapRepo<ls::RuntimeStringNoVersionHashOps>*, ls::EnumFlags<ls::EAddFlags>)"},
@@ -64,23 +82,24 @@
     {"name": "BinkManager::LoadVideo", "baseline": "0x10390b6cc", "symbol": "bik::BinkManager::LoadVideo(ls::Path const&)", "_note": "unchanged 6995620 -> 7209685; verify it still maps to this symbol"}
   ],
 
-  "_data_singletons_note": "baseline = offset from binary base (the value stored in offset_table.c, i.e. Ghidra addr - 0x100000000). result = baseline + data_shift.",
+  "_data_singletons_note": "baseline = offset from binary base for 4.1.1.6995620 (cross-check only). Primary resolution is per-entry `method`; data_shift is never assumed for these (global_switches_ptr proved the shift non-uniform).",
   "data_singletons": [
-    {"field": "eocserver_ptr",           "baseline": "0x0898e8b8", "method": "data_shift", "note": "esv::EocServer::m_ptr (not exported)"},
-    {"field": "eocclient_ptr",           "baseline": "0x0898c968", "method": "data_shift", "note": "ecl::EocClient::m_ptr (not exported)"},
-    {"field": "spell_proto_mgr_ptr",     "baseline": "0x089bac80", "method": "data_shift", "note": "SpellPrototypeManager::m_ptr (not exported)"},
-    {"field": "rpgstats_ptr",            "baseline": "0x089c5730", "method": "data_shift", "note": "RPGStats::m_ptr (not exported)"},
-    {"field": "resource_mgr_ptr",        "baseline": "0x08a8f070", "method": "data_shift", "note": "ResourceManager::m_ptr (not exported)"},
-    {"field": "level_mgr_ptr",           "baseline": "0x08a3be40", "method": "data_shift", "note": "LevelManager::m_ptr (not exported)"},
-    {"field": "global_template_mgr_ptr", "baseline": "0x08a88508", "method": "data_shift", "note": "ls::GlobalTemplateManager::m_ptr (not exported)"},
-    {"field": "cache_template_mgr_ptr",  "baseline": "0x08a309a8", "method": "data_shift", "note": "CacheTemplateManager::m_ptr (not exported)"},
-    {"field": "level_cache_mgr_ptr",     "baseline": "0x08a735d8", "method": "data_shift", "note": "Level::s_CacheTemplateManager (not exported)"},
-    {"field": "staticdata_mstate_ptr",   "baseline": "0x083c4a68", "method": "data_shift", "note": "PTR to ImmutableDataHeadmaster TypeContext m_State (not exported)"},
-    {"field": "gst_ptr",                 "baseline": "0x08aeccd8", "method": "data_shift", "note": "ls::gGlobalStringTable subtable base ptr (verify via ls::gst::Get disasm)"}
+    {"field": "eocserver_ptr",           "baseline": "0x0898e8b8", "method": "symbol", "symbol": "esv::EocServer::m_ptr"},
+    {"field": "eocclient_ptr",           "baseline": "0x0898c968", "method": "symbol", "symbol": "ecl::EocClient::m_ptr"},
+    {"field": "spell_proto_mgr_ptr",     "baseline": "0x089bac80", "method": "symbol", "symbol": "eoc::SpellPrototypeManager::m_ptr"},
+    {"field": "rpgstats_ptr",            "baseline": "0x089c5730", "method": "symbol", "symbol": "RPGStats::m_ptr"},
+    {"field": "resource_mgr_ptr",        "baseline": "0x08a8f070", "method": "symbol", "symbol": "ls::ResourceManager::m_ptr"},
+    {"field": "level_mgr_ptr",           "baseline": "0x08a3be40", "method": "symbol", "symbol": "esv::LevelManager::m_ptr"},
+    {"field": "global_template_mgr_ptr", "baseline": "0x08a88508", "method": "symbol", "symbol": "ls::GlobalTemplateManager::m_ptr"},
+    {"field": "cache_template_mgr_ptr",  "baseline": "0x08a309a8", "method": "symbol", "symbol": "esv::CacheTemplateManager::m_ptr"},
+    {"field": "level_cache_mgr_ptr",     "baseline": "0x08a735d8", "method": "symbol", "symbol": "esv::Level::s_CacheTemplateManager"},
+    {"field": "staticdata_mstate_ptr",   "baseline": "0x083c4a68", "method": "got",    "symbol": "ls::TypeContext<ls::ImmutableDataHeadmaster>::m_State", "note": "resolve the __got SLOT mapped to this symbol (otool -Iv); the code dereferences the slot once"},
+    {"field": "gst_ptr",                 "baseline": "0x08aeccd8", "method": "symbol", "symbol": "ls::gst::s_Instance"},
+    {"field": "global_switches_ptr",     "baseline": "0x08b18f30", "method": "disasm", "note": "EoCGlobalSwitches* double-pointer slot; anonymous __common, no symbol. Re-derive via ADRP+LDR scan (hot slot, ~900 refs; written by App::CreateGlobalSwitches). 7209685 = 0x08af4f30 (moved -0x24000, NOT +0x8000). Runtime read-back guard in global_switches.c."}
   ],
 
   "exported_data": [
-    {"name": "TranslatedStringRepository::m_ptr", "baseline": "0x108aed088", "symbol": "ls::TranslatedStringRepository::m_ptr", "consumer": "localization.c LOCA_REPO_OFFSET", "_note": "exported 'b' symbol; also equals data_shift result -- good cross-check"}
+    {"name": "TranslatedStringRepository::m_ptr", "baseline": "0x108aed088", "symbol": "ls::TranslatedStringRepository::m_ptr", "consumer": "localization.c LOCA_REPO_OFFSET (7209685-vintage constant, adjusted at runtime by component_data_shift)", "_note": "nm 'b' symbol; baseline is the 6995620 VA (cross-check only)"}
   ],
 
   "struct_offsets": [

--- a/tools/offset_manifest.json
+++ b/tools/offset_manifest.json
@@ -33,84 +33,309 @@
     "demangled signature against the wrapper in the C code before enabling a hook",
     "(the 7209685 Interrupt ExecuteStatsFunctors gained a leading ecs::EntityWorld&)."
   ],
-
   "baseline_version": "4.1.1.6995620",
   "constants_vintage": "4.1.1.7209685",
-
   "data_shift_anchor": {
     "_note": "Derives component_data_shift = nm(symbol) - baseline, the signed delta from the 7209685-vintage compiled-in TypeId constants to the target version. 0 on 7209685 itself; -0x8000 on 6995620.",
     "symbol": "ls::TypeId<eoc::FeatManager, ls::ImmutableDataHeadmaster>::m_TypeIndex",
     "baseline": "0x1088f7d00"
   },
-
   "offset_table_functions": [
-    {"field": "fn_feat_getfeats",      "baseline": "0x101b752b4", "symbol": "eoc::FeatManager::GetFeats() const"},
-    {"field": "fn_getallfeats",        "baseline": "0x10120b3e8", "symbol": "eoc::character_creation::GetAllFeats(eoc::character_creation::Environment const&)"},
-    {"field": "fn_get_background",     "baseline": "0x102994834", "symbol": "eoc::BackgroundManager const* ls::ImmutableDataHeadmaster::Get<eoc::BackgroundManager>() const"},
-    {"field": "fn_get_origin",         "baseline": "0x10341c42c", "symbol": "eoc::OriginManager const* ls::ImmutableDataHeadmaster::Get<eoc::OriginManager>() const"},
-    {"field": "fn_get_class",          "baseline": "0x10262f184", "symbol": "eoc::ClassDescriptions const* ls::ImmutableDataHeadmaster::Get<eoc::ClassDescriptions>() const"},
-    {"field": "fn_get_progression",    "baseline": "0x103697f0c", "symbol": "eoc::ProgressionManager const* ls::ImmutableDataHeadmaster::Get<eoc::ProgressionManager>() const"},
-    {"field": "fn_get_actionresource", "baseline": "0x1011a4494", "symbol": "eoc::ActionResourceTypes const* ls::ImmutableDataHeadmaster::Get<eoc::ActionResourceTypes>() const"},
-    {"field": "fn_get_template_raw",   "baseline": "0x105f96304", "symbol": "ls::GlobalTemplateManager::GetTemplateRaw(ls::FixedString const&) const"},
-    {"field": "fn_cache_template",     "baseline": "0x105d31ce4", "symbol": "ls::CacheTemplateManagerBase::CacheTemplate(ls::GameObjectTemplate const*, ls::FixedString const&, ls::FixedString const&)"},
-    {"field": "fn_try_get_uuid_mapping","baseline": "0x1010dc924", "symbol": "ls::Result<ecs::_private::EntityViewFinder<ecs::_private::QueryViewFinder<ecs::query::alive::Spec<ls::TypeList<ls::uuid::ToHandleMappingComponent const>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ecs::QueryTypePersistentTag, ecs::QueryTypeAliveTag>>::type>::type, ls::Error> ecs::legacy::Helper::TryGetSingleton<ecs::query::alive::Spec<ls::TypeList<ls::uuid::ToHandleMappingComponent const>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ecs::QueryTypePersistentTag, ecs::QueryTypeAliveTag>>(ecs::EntityWorld&)"},
-    {"field": "fn_storage_tryget",     "baseline": "0x10636b27c", "symbol": "ecs::EntityStorageContainer::TryGet(ls::ID<ecs::EntityHandleTraits>)"},
-    {"field": "fn_spell_proto_init",   "baseline": "0x101f72754", "symbol": "eoc::SpellPrototype::Init(ls::FixedString const&)"}
+    {
+      "field": "fn_feat_getfeats",
+      "baseline": "0x101b752b4",
+      "symbol": "eoc::FeatManager::GetFeats() const"
+    },
+    {
+      "field": "fn_getallfeats",
+      "baseline": "0x10120b3e8",
+      "symbol": "eoc::character_creation::GetAllFeats(eoc::character_creation::Environment const&)"
+    },
+    {
+      "field": "fn_get_background",
+      "baseline": "0x102994834",
+      "symbol": "eoc::BackgroundManager const* ls::ImmutableDataHeadmaster::Get<eoc::BackgroundManager>() const"
+    },
+    {
+      "field": "fn_get_origin",
+      "baseline": "0x10341c42c",
+      "symbol": "eoc::OriginManager const* ls::ImmutableDataHeadmaster::Get<eoc::OriginManager>() const"
+    },
+    {
+      "field": "fn_get_class",
+      "baseline": "0x10262f184",
+      "symbol": "eoc::ClassDescriptions const* ls::ImmutableDataHeadmaster::Get<eoc::ClassDescriptions>() const"
+    },
+    {
+      "field": "fn_get_progression",
+      "baseline": "0x103697f0c",
+      "symbol": "eoc::ProgressionManager const* ls::ImmutableDataHeadmaster::Get<eoc::ProgressionManager>() const"
+    },
+    {
+      "field": "fn_get_actionresource",
+      "baseline": "0x1011a4494",
+      "symbol": "eoc::ActionResourceTypes const* ls::ImmutableDataHeadmaster::Get<eoc::ActionResourceTypes>() const"
+    },
+    {
+      "field": "fn_get_template_raw",
+      "baseline": "0x105f96304",
+      "symbol": "ls::GlobalTemplateManager::GetTemplateRaw(ls::FixedString const&) const"
+    },
+    {
+      "field": "fn_cache_template",
+      "baseline": "0x105d31ce4",
+      "symbol": "ls::CacheTemplateManagerBase::CacheTemplate(ls::GameObjectTemplate const*, ls::FixedString const&, ls::FixedString const&)"
+    },
+    {
+      "field": "fn_try_get_uuid_mapping",
+      "baseline": "0x1010dc924",
+      "symbol": "ls::Result<ecs::_private::EntityViewFinder<ecs::_private::QueryViewFinder<ecs::query::alive::Spec<ls::TypeList<ls::uuid::ToHandleMappingComponent const>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ecs::QueryTypePersistentTag, ecs::QueryTypeAliveTag>>::type>::type, ls::Error> ecs::legacy::Helper::TryGetSingleton<ecs::query::alive::Spec<ls::TypeList<ls::uuid::ToHandleMappingComponent const>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ls::TypeList<>, ecs::QueryTypePersistentTag, ecs::QueryTypeAliveTag>>(ecs::EntityWorld&)"
+    },
+    {
+      "field": "fn_storage_tryget",
+      "baseline": "0x10636b27c",
+      "symbol": "ecs::EntityStorageContainer::TryGet(ls::ID<ecs::EntityHandleTraits>)"
+    },
+    {
+      "field": "fn_spell_proto_init",
+      "baseline": "0x101f72754",
+      "symbol": "eoc::SpellPrototype::Init(ls::FixedString const&)"
+    }
   ],
-
   "remap_functions": [
-    {"name": "FixedString::Create",        "baseline": "0x1064b9ebc", "symbol": "ls::FixedString::Create(char const*, int)"},
-    {"name": "ResourceContainer::GetResource","baseline": "0x1060cc608", "symbol": "ls::ResourceContainer::GetResource(ls::EResourceType, ls::FixedString const&) const"},
-    {"name": "ExecuteStatsFunctor",        "baseline": "0x105783a38", "symbol": "ExecuteStatsFunctor(eoc::StatsFunctorBase const*, unsigned long, esv::functor::AttackTargetContextData&)"},
-    {"name": "ExecuteFunctors<AttackTarget>","baseline": "0x105787918", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::AttackTargetContextData&)"},
-    {"name": "ExecuteFunctors<AttackPosition>","baseline": "0x105787c6c","symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::AttackPositionContextData&)"},
-    {"name": "ExecuteFunctors<Move>",      "baseline": "0x10578975c", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::MoveContextData&)"},
-    {"name": "ExecuteFunctors<Target>",    "baseline": "0x10578a918", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::TargetContextData&)"},
-    {"name": "ExecuteFunctors<NearbyAttacked>","baseline": "0x10578e4d8","symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::NearbyAttackedContextData&)"},
-    {"name": "ExecuteFunctors<NearbyAttacking>","baseline": "0x10578fba8","symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::NearbyAttackingContextData&)"},
-    {"name": "ExecuteFunctors<Equip>",     "baseline": "0x105790a28", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::EquipContextData&)"},
-    {"name": "ExecuteFunctors<Source>",    "baseline": "0x105792a90", "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::SourceContextData&)"},
-    {"name": "ExecuteFunctors<Interrupt>", "baseline": "0x1057965e4", "symbol": "esv::functor::ExecuteStatsFunctors(ecs::EntityWorld&, eoc::StatsFunctorList const*, esv::functor::InterruptContextData&)", "abi_changed": true, "_note": "the 6995620 variant had NO EntityWorld& param -- the existing wrapper ABI does not fit. Emit 0 in the remap column until functor_hooks.c grows an EntityWorld-aware wrapper."},
-    {"name": "TranslatedStringRepository::TryGet","baseline": "0x106534d54","symbol": "ls::TranslatedStringRepository::TryGet(ls::RuntimeStringHandle const&, ls::identity::EIdentity, ls::identity::EIdentity) const"},
-    {"name": "TranslatedStringRepository::Get","baseline": "0x106535148","symbol": "ls::TranslatedStringRepository::Get(ls::RuntimeStringHandle const&, ls::identity::EIdentity, ls::identity::EIdentity) const"},
-    {"name": "TranslatedStringRepository::AddTranslatedString","baseline": "0x106532590","symbol": "ls::TranslatedStringRepository::AddTranslatedString(ls::RuntimeStringHandle, ls::_StringView<char>, ls::TranslatedMapRepo<ls::RuntimeStringNoVersionHashOps>*, ls::EnumFlags<ls::EAddFlags>)"},
-    {"name": "MessageFactory::GetFreeMessage","baseline": "0x1063d5998","symbol": "net::MessageFactory::GetFreeMessage(int)"},
-    {"name": "STDString::STDString(char const*)","baseline": "0x10651fb60","symbol": "ls::STDString::STDString(char const*)"}
+    {
+      "name": "FixedString::Create",
+      "baseline": "0x1064b9ebc",
+      "symbol": "ls::FixedString::Create(char const*, int)"
+    },
+    {
+      "name": "ResourceContainer::GetResource",
+      "baseline": "0x1060cc608",
+      "symbol": "ls::ResourceContainer::GetResource(ls::EResourceType, ls::FixedString const&) const"
+    },
+    {
+      "name": "ExecuteStatsFunctor",
+      "baseline": "0x105783a38",
+      "symbol": "ExecuteStatsFunctor(eoc::StatsFunctorBase const*, unsigned long, esv::functor::AttackTargetContextData&)"
+    },
+    {
+      "name": "ExecuteFunctors<AttackTarget>",
+      "baseline": "0x105787918",
+      "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::AttackTargetContextData&)"
+    },
+    {
+      "name": "ExecuteFunctors<AttackPosition>",
+      "baseline": "0x105787c6c",
+      "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::AttackPositionContextData&)"
+    },
+    {
+      "name": "ExecuteFunctors<Move>",
+      "baseline": "0x10578975c",
+      "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::MoveContextData&)"
+    },
+    {
+      "name": "ExecuteFunctors<Target>",
+      "baseline": "0x10578a918",
+      "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::TargetContextData&)"
+    },
+    {
+      "name": "ExecuteFunctors<NearbyAttacked>",
+      "baseline": "0x10578e4d8",
+      "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::NearbyAttackedContextData&)"
+    },
+    {
+      "name": "ExecuteFunctors<NearbyAttacking>",
+      "baseline": "0x10578fba8",
+      "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::NearbyAttackingContextData&)"
+    },
+    {
+      "name": "ExecuteFunctors<Equip>",
+      "baseline": "0x105790a28",
+      "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::EquipContextData&)"
+    },
+    {
+      "name": "ExecuteFunctors<Source>",
+      "baseline": "0x105792a90",
+      "symbol": "esv::functor::ExecuteStatsFunctors(eoc::StatsFunctorList const*, esv::functor::SourceContextData&)"
+    },
+    {
+      "name": "ExecuteFunctors<Interrupt>",
+      "baseline": "0x1057965e4",
+      "symbol": "esv::functor::ExecuteStatsFunctors(ecs::EntityWorld&, eoc::StatsFunctorList const*, esv::functor::InterruptContextData&)",
+      "abi_changed": true,
+      "_note": "the 6995620 variant had NO EntityWorld& param -- the existing wrapper ABI does not fit. Emit 0 in the remap column until functor_hooks.c grows an EntityWorld-aware wrapper."
+    },
+    {
+      "name": "TranslatedStringRepository::TryGet",
+      "baseline": "0x106534d54",
+      "symbol": "ls::TranslatedStringRepository::TryGet(ls::RuntimeStringHandle const&, ls::identity::EIdentity, ls::identity::EIdentity) const"
+    },
+    {
+      "name": "TranslatedStringRepository::Get",
+      "baseline": "0x106535148",
+      "symbol": "ls::TranslatedStringRepository::Get(ls::RuntimeStringHandle const&, ls::identity::EIdentity, ls::identity::EIdentity) const"
+    },
+    {
+      "name": "TranslatedStringRepository::AddTranslatedString",
+      "baseline": "0x106532590",
+      "symbol": "ls::TranslatedStringRepository::AddTranslatedString(ls::RuntimeStringHandle, ls::_StringView<char>, ls::TranslatedMapRepo<ls::RuntimeStringNoVersionHashOps>*, ls::EnumFlags<ls::EAddFlags>)"
+    },
+    {
+      "name": "MessageFactory::GetFreeMessage",
+      "baseline": "0x1063d5998",
+      "symbol": "net::MessageFactory::GetFreeMessage(int)"
+    },
+    {
+      "name": "STDString::STDString(char const*)",
+      "baseline": "0x10651fb60",
+      "symbol": "ls::STDString::STDString(char const*)"
+    }
   ],
-
   "constant_functions": [
-    {"name": "BinkManager::LoadVideo", "baseline": "0x10390b6cc", "symbol": "bik::BinkManager::LoadVideo(ls::Path const&)", "_note": "unchanged 6995620 -> 7209685; verify it still maps to this symbol"}
+    {
+      "name": "BinkManager::LoadVideo",
+      "baseline": "0x10390b6cc",
+      "symbol": "bik::BinkManager::LoadVideo(ls::Path const&)",
+      "_note": "unchanged 6995620 -> 7209685; verify it still maps to this symbol"
+    }
   ],
-
   "_data_singletons_note": "baseline = offset from binary base for 4.1.1.6995620 (cross-check only). Primary resolution is per-entry `method`; data_shift is never assumed for these (global_switches_ptr proved the shift non-uniform).",
   "data_singletons": [
-    {"field": "eocserver_ptr",           "baseline": "0x0898e8b8", "method": "symbol", "symbol": "esv::EocServer::m_ptr"},
-    {"field": "eocclient_ptr",           "baseline": "0x0898c968", "method": "symbol", "symbol": "ecl::EocClient::m_ptr"},
-    {"field": "spell_proto_mgr_ptr",     "baseline": "0x089bac80", "method": "symbol", "symbol": "eoc::SpellPrototypeManager::m_ptr"},
-    {"field": "rpgstats_ptr",            "baseline": "0x089c5730", "method": "symbol", "symbol": "RPGStats::m_ptr"},
-    {"field": "resource_mgr_ptr",        "baseline": "0x08a8f070", "method": "symbol", "symbol": "ls::ResourceManager::m_ptr"},
-    {"field": "level_mgr_ptr",           "baseline": "0x08a3be40", "method": "symbol", "symbol": "esv::LevelManager::m_ptr"},
-    {"field": "global_template_mgr_ptr", "baseline": "0x08a88508", "method": "symbol", "symbol": "ls::GlobalTemplateManager::m_ptr"},
-    {"field": "cache_template_mgr_ptr",  "baseline": "0x08a309a8", "method": "symbol", "symbol": "esv::CacheTemplateManager::m_ptr"},
-    {"field": "level_cache_mgr_ptr",     "baseline": "0x08a735d8", "method": "symbol", "symbol": "esv::Level::s_CacheTemplateManager"},
-    {"field": "staticdata_mstate_ptr",   "baseline": "0x083c4a68", "method": "got",    "symbol": "ls::TypeContext<ls::ImmutableDataHeadmaster>::m_State", "note": "resolve the __got SLOT mapped to this symbol (otool -Iv); the code dereferences the slot once"},
-    {"field": "gst_ptr",                 "baseline": "0x08aeccd8", "method": "symbol", "symbol": "ls::gst::s_Instance"},
-    {"field": "global_switches_ptr",     "baseline": "0x08b18f30", "method": "disasm", "note": "EoCGlobalSwitches* double-pointer slot; anonymous __common, no symbol. Re-derive via ADRP+LDR scan (hot slot, ~900 refs; written by App::CreateGlobalSwitches). 7209685 = 0x08af4f30 (moved -0x24000, NOT +0x8000). Runtime read-back guard in global_switches.c."}
+    {
+      "field": "eocserver_ptr",
+      "baseline": "0x0898e8b8",
+      "method": "symbol",
+      "symbol": "esv::EocServer::m_ptr"
+    },
+    {
+      "field": "eocclient_ptr",
+      "baseline": "0x0898c968",
+      "method": "symbol",
+      "symbol": "ecl::EocClient::m_ptr"
+    },
+    {
+      "field": "spell_proto_mgr_ptr",
+      "baseline": "0x089bac80",
+      "method": "symbol",
+      "symbol": "eoc::SpellPrototypeManager::m_ptr"
+    },
+    {
+      "field": "rpgstats_ptr",
+      "baseline": "0x089c5730",
+      "method": "symbol",
+      "symbol": "RPGStats::m_ptr"
+    },
+    {
+      "field": "resource_mgr_ptr",
+      "baseline": "0x08a8f070",
+      "method": "symbol",
+      "symbol": "ls::ResourceManager::m_ptr"
+    },
+    {
+      "field": "level_mgr_ptr",
+      "baseline": "0x08a3be40",
+      "method": "symbol",
+      "symbol": "esv::LevelManager::m_ptr"
+    },
+    {
+      "field": "global_template_mgr_ptr",
+      "baseline": "0x08a88508",
+      "method": "symbol",
+      "symbol": "ls::GlobalTemplateManager::m_ptr"
+    },
+    {
+      "field": "cache_template_mgr_ptr",
+      "baseline": "0x08a309a8",
+      "method": "symbol",
+      "symbol": "esv::CacheTemplateManager::m_ptr"
+    },
+    {
+      "field": "level_cache_mgr_ptr",
+      "baseline": "0x08a735d8",
+      "method": "symbol",
+      "symbol": "esv::Level::s_CacheTemplateManager"
+    },
+    {
+      "field": "staticdata_mstate_ptr",
+      "baseline": "0x083c4a68",
+      "method": "got",
+      "symbol": "ls::TypeContext<ls::ImmutableDataHeadmaster>::m_State",
+      "note": "resolve the __got SLOT mapped to this symbol (otool -Iv); the code dereferences the slot once"
+    },
+    {
+      "field": "gst_ptr",
+      "baseline": "0x08aeccd8",
+      "method": "symbol",
+      "symbol": "ls::gst::s_Instance"
+    },
+    {
+      "field": "global_switches_ptr",
+      "baseline": "0x08b18f30",
+      "method": "disasm",
+      "note": "EoCGlobalSwitches* double-pointer slot; anonymous __common, no symbol. Re-derive via ADRP+LDR scan (hot slot, ~900 refs; written by App::CreateGlobalSwitches). 7209685 = 0x08af4f30 (moved -0x24000, NOT +0x8000). Runtime read-back guard in global_switches.c."
+    },
+    {
+      "field": "osiris_interface_ptr",
+      "baseline": "0x08a86128",
+      "method": "disasm",
+      "note": "osi::OsirisInterface global instance slot (used by osi_read_param_defs). No symbol. Authoritative reference: the first adrp+ldr pair in osi::OsirisInterface::OsirisQuery after the stack-guard load (otool -tV -p on the mangled name). 7209685 = 0x08a86128 (adrp 0x108a86000 + ldr #0x128, verified 2026-07-29). Audited every run by test_offset_audit.py::test_osiris_interface_slot_matches_disasm. Baseline here is the 7209685 value; the 6995620 row is 0 (never verified on that vintage)."
+    }
   ],
-
   "exported_data": [
-    {"name": "TranslatedStringRepository::m_ptr", "baseline": "0x108aed088", "symbol": "ls::TranslatedStringRepository::m_ptr", "consumer": "localization.c LOCA_REPO_OFFSET (7209685-vintage constant, adjusted at runtime by component_data_shift)", "_note": "nm 'b' symbol; baseline is the 6995620 VA (cross-check only)"}
+    {
+      "name": "TranslatedStringRepository::m_ptr",
+      "baseline": "0x108aed088",
+      "symbol": "ls::TranslatedStringRepository::m_ptr",
+      "consumer": "localization.c LOCA_REPO_OFFSET (7209685-vintage constant, adjusted at runtime by component_data_shift)",
+      "_note": "nm 'b' symbol; baseline is the 6995620 VA (cross-check only)"
+    }
   ],
-
   "struct_offsets": [
-    {"name": "EocServer -> EntityWorld",          "value": "0x288",  "where": "entity_system.c OFFSET_ENTITYWORLD_IN_EOCSERVER", "verify_via": "esv::EocServer::StartUp disasm: ldr xN,[this,#0x288]"},
-    {"name": "EntityWorld -> StorageContainer",   "value": "0x2d0",  "where": "component_templates.h ENTITYWORLD_STORAGE_OFFSET"},
-    {"name": "EntityWorld -> ImmediateWorldCache","value": "0x3f0",  "where": "component_templates.h ENTITYWORLD_CACHE_OFFSET"},
-    {"name": "RPGStats -> FixedStrings pool",     "value": "0x348",  "where": "ghidra/offsets/STATS.md"},
-    {"name": "RefMap capacity",                   "value": "0x10",   "where": "prototype_managers.c REFMAP_OFFSET_CAPACITY"},
-    {"name": "RefMap keys array",                 "value": "0x28",   "where": "prototype_managers.c REFMAP_OFFSET_KEYS"},
-    {"name": "RefMap values array",               "value": "0x38",   "where": "prototype_managers.c REFMAP_OFFSET_VALUES"},
-    {"name": "Stat object -> name FixedString",   "value": "0x20",   "where": "stats_manager.c STATS_OBJECT_OFFSET_NAME"},
-    {"name": "GST subtable stride",               "value": "0x1200", "where": "fixed_string.c (ls::gst::Get: umaddl ... #0x1200)"}
+    {
+      "name": "EocServer -> EntityWorld",
+      "value": "0x288",
+      "where": "entity_system.c OFFSET_ENTITYWORLD_IN_EOCSERVER",
+      "verify_via": "esv::EocServer::StartUp disasm: ldr xN,[this,#0x288]"
+    },
+    {
+      "name": "EntityWorld -> StorageContainer",
+      "value": "0x2d0",
+      "where": "component_templates.h ENTITYWORLD_STORAGE_OFFSET"
+    },
+    {
+      "name": "EntityWorld -> ImmediateWorldCache",
+      "value": "0x3f0",
+      "where": "component_templates.h ENTITYWORLD_CACHE_OFFSET"
+    },
+    {
+      "name": "RPGStats -> FixedStrings pool",
+      "value": "0x348",
+      "where": "ghidra/offsets/STATS.md"
+    },
+    {
+      "name": "RefMap capacity",
+      "value": "0x10",
+      "where": "prototype_managers.c REFMAP_OFFSET_CAPACITY"
+    },
+    {
+      "name": "RefMap keys array",
+      "value": "0x28",
+      "where": "prototype_managers.c REFMAP_OFFSET_KEYS"
+    },
+    {
+      "name": "RefMap values array",
+      "value": "0x38",
+      "where": "prototype_managers.c REFMAP_OFFSET_VALUES"
+    },
+    {
+      "name": "Stat object -> name FixedString",
+      "value": "0x20",
+      "where": "stats_manager.c STATS_OBJECT_OFFSET_NAME"
+    },
+    {
+      "name": "GST subtable stride",
+      "value": "0x1200",
+      "where": "fixed_string.c (ls::gst::Get: umaddl ... #0x1200)"
+    }
   ]
 }

--- a/tools/port_offsets.py
+++ b/tools/port_offsets.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+port_offsets.py — resolve BG3SE-macOS per-version addresses against a BG3 binary.
+
+The macOS BG3 binary keeps its symbol table, so almost every per-version address
+is a `nm` lookup. This tool reads tools/offset_manifest.json (the recipe) and, for
+a target binary, resolves every address and emits ready-to-paste offset_table.c
+content. Anything it can't resolve is flagged — that's your signal that a struct
+changed and you need Ghidra/runtime probing for that one item.
+
+Usage:
+  python3 tools/port_offsets.py resolve [--binary PATH] [--emit]
+  python3 tools/port_offsets.py verify  [--binary PATH]   # diff vs offset_table.c
+
+See docs/PORTING.md.
+"""
+import argparse, json, os, re, subprocess, sys, tempfile, plistlib
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+MANIFEST = os.path.join(HERE, "offset_manifest.json")
+OFFSET_TABLE_C = os.path.join(REPO, "src", "core", "offset_table.c")
+GHIDRA_BASE = 0x100000000
+
+DEFAULT_BINARY = os.path.expanduser(
+    "~/Library/Application Support/Steam/steamapps/common/"
+    "Baldurs Gate 3/Baldur's Gate 3.app/Contents/MacOS/Baldur's Gate 3"
+)
+
+# ----------------------------------------------------------------------------
+# Binary + symbol handling
+# ----------------------------------------------------------------------------
+
+def thin_arm64(binary):
+    """Return a path to an arm64 thin slice (extracting if the binary is fat)."""
+    archs = subprocess.run(["lipo", "-archs", binary], capture_output=True, text=True)
+    if archs.returncode != 0:
+        # not a fat binary / lipo failed — assume it's already thin
+        return binary
+    if "arm64" not in archs.stdout.split():
+        sys.exit(f"error: {binary} has no arm64 slice (archs: {archs.stdout.strip()})")
+    if archs.stdout.split() == ["arm64"]:
+        return binary
+    out = os.path.join(tempfile.gettempdir(), "bg3_arm64_thin_port")
+    subprocess.run(["lipo", "-thin", "arm64", binary, "-output", out], check=True)
+    return out
+
+def norm(s):
+    """Normalize a C++ signature for matching (whitespace-insensitive)."""
+    return re.sub(r"\s+", "", s)
+
+def build_symbol_map(thin):
+    """{normalized_demangled_name: set(addresses)} from nm + c++filt."""
+    raw = subprocess.run(["nm", thin], capture_output=True, text=True).stdout
+    dem = subprocess.run(["c++filt"], input=raw, capture_output=True, text=True).stdout
+    table = {}
+    for line in dem.splitlines():
+        parts = line.split(" ", 2)
+        if len(parts) < 3:
+            continue
+        addr, typ, name = parts
+        if not re.fullmatch(r"[0-9a-fA-F]+", addr):
+            continue  # undefined symbol (no address)
+        table.setdefault(norm(name), set()).add(int(addr, 16))
+    return table
+
+def lookup(symtab, symbol):
+    """Return (addr, note). note flags ambiguity/missing."""
+    addrs = symtab.get(norm(symbol))
+    if not addrs:
+        return None, "NOT FOUND"
+    if len(addrs) > 1:
+        return sorted(addrs)[0], f"AMBIGUOUS ({len(addrs)} matches; took lowest)"
+    return next(iter(addrs)), ""
+
+def detect_version(binary):
+    info = os.path.join(os.path.dirname(os.path.dirname(binary)), "Info.plist")
+    try:
+        with open(info, "rb") as f:
+            return plistlib.load(f).get("CFBundleShortVersionString")
+    except Exception:
+        return None
+
+def hx(v):
+    return f"0x{v:08x}"
+
+# ----------------------------------------------------------------------------
+# Resolution
+# ----------------------------------------------------------------------------
+
+def resolve(manifest, symtab):
+    """Return a dict of resolved values + a list of (level, message) issues."""
+    issues = []
+    out = {"fn": {}, "data": {}, "remap": [], "exported": {}, "constants": [], "struct": []}
+
+    # 1. derive the __DATA shift from the anchor
+    anchor = manifest["data_shift_anchor"]
+    a_addr, a_note = lookup(symtab, anchor["symbol"])
+    if a_addr is None:
+        issues.append(("FATAL", f"data_shift anchor '{anchor['symbol']}' not found — "
+                                "cannot derive __DATA shift. Pick another exported anchor."))
+        return out, issues
+    shift = a_addr - int(anchor["baseline"], 16)
+    out["data_shift"] = shift
+    issues.append(("INFO", f"__DATA shift derived from anchor: {hx(shift)} "
+                           f"(anchor {anchor['symbol'].split('(')[0]} {hx(int(anchor['baseline'],16))} -> 0x{a_addr:x})"))
+
+    # 2. offset_table functions (symbol)
+    for e in manifest["offset_table_functions"]:
+        addr, note = lookup(symtab, e["symbol"])
+        if addr is None:
+            issues.append(("ERROR", f"offset_table.{e['field']}: symbol not found ({e['symbol'][:60]}...)"))
+        else:
+            out["fn"][e["field"]] = addr - GHIDRA_BASE
+            if note:
+                issues.append(("WARN", f"offset_table.{e['field']}: {note}"))
+
+    # 3. data singletons (data_shift)
+    for e in manifest["data_singletons"]:
+        out["data"][e["field"]] = int(e["baseline"], 16) + shift
+
+    # 4. exported data (symbol; cross-check against data_shift where applicable)
+    for e in manifest["exported_data"]:
+        addr, note = lookup(symtab, e["symbol"])
+        if addr is None:
+            issues.append(("ERROR", f"exported_data {e['name']}: symbol not found"))
+        else:
+            out["exported"][e["name"]] = addr
+            base = e.get("baseline")
+            if base and (addr - int(base, 16)) != shift:
+                issues.append(("WARN", f"exported_data {e['name']}: shift {hx(addr-int(base,16))} "
+                                       f"!= __DATA shift {hx(shift)} (segment may differ)"))
+
+    # 5. remap functions (symbol)
+    for e in manifest["remap_functions"]:
+        addr, note = lookup(symtab, e["symbol"])
+        if addr is None:
+            issues.append(("ERROR", f"remap {e['name']}: symbol not found ({e['symbol'][:60]}...)"))
+        else:
+            out["remap"].append((int(e["baseline"], 16), addr, e["name"]))
+            if note:
+                issues.append(("WARN", f"remap {e['name']}: {note}"))
+
+    # 6. constant functions (verify unchanged)
+    for e in manifest.get("constant_functions", []):
+        addr, note = lookup(symtab, e["symbol"])
+        base = int(e["baseline"], 16)
+        if addr is None:
+            issues.append(("WARN", f"constant {e['name']}: symbol not found — cannot verify it is unchanged"))
+        elif addr != base:
+            issues.append(("ERROR", f"constant {e['name']}: CHANGED {hx(base)} -> 0x{addr:x} "
+                                    "— it is NOT constant for this version; promote it to remap_functions"))
+        out["constants"].append((e["name"], base, addr))
+
+    # 7. struct offsets — carried, not re-resolved (documented)
+    out["struct"] = manifest.get("struct_offsets", [])
+    return out, issues
+
+# ----------------------------------------------------------------------------
+# Output
+# ----------------------------------------------------------------------------
+
+def emit_c(out, version):
+    L = []
+    L.append(f"    /* ---- generated by tools/port_offsets.py for {version} ---- */")
+    L.append("    {")
+    L.append(f'        .version                 = "{version}",')
+    L.append("")
+    L.append("        /* Singleton pointer globals (data_shift = %s) */" % hx(out["data_shift"]))
+    for field, val in out["data"].items():
+        L.append(f"        .{field:<24} = {hx(val)},")
+    L.append("")
+    L.append("        /* Function offsets (symbol-resolved) */")
+    for field, val in out["fn"].items():
+        L.append(f"        .{field:<24} = {hx(val)},")
+    L.append(f"        .component_data_shift    = {hx(out['data_shift'])},")
+    L.append("    },")
+    L.append("")
+    L.append(f"    /* g_fn_remap_<ver> entries for {version}: */")
+    for base, new, name in out["remap"]:
+        L.append(f"    {{ 0x{base:09x}, 0x{new:09x} }},  // {name}")
+    return "\n".join(L)
+
+# ----------------------------------------------------------------------------
+# verify: compare generated values against what's in offset_table.c
+# ----------------------------------------------------------------------------
+
+def parse_offset_table_c(version):
+    """Extract the {.field = 0x..} block for `version` and the remap pairs."""
+    txt = open(OFFSET_TABLE_C).read()
+    fields = {}
+    # find the struct entry for this version
+    m = re.search(r'\.version\s*=\s*"' + re.escape(version) + r'"(.*?)\n\s*\},', txt, re.S)
+    if m:
+        for fm in re.finditer(r'\.(\w+)\s*=\s*(0x[0-9a-fA-F]+)', m.group(1)):
+            fields[fm.group(1)] = int(fm.group(2), 16)
+    remap = []
+    rm = re.search(r'g_fn_remap_\w+\[\]\s*=\s*\{(.*?)\n\};', txt, re.S)
+    if rm:
+        for pm in re.finditer(r'\{\s*(0x[0-9a-fA-F]+)\s*,\s*(0x[0-9a-fA-F]+)\s*\}', rm.group(1)):
+            remap.append((int(pm.group(1), 16), int(pm.group(2), 16)))
+    return fields, remap
+
+def do_verify(out, version):
+    fields, remap = parse_offset_table_c(version)
+    if not fields:
+        print(f"  (no '{version}' entry in offset_table.c to verify against)")
+        return 0
+    mism = 0
+    gen = {**out["data"], **out["fn"], "component_data_shift": out["data_shift"]}
+    for f, v in gen.items():
+        cur = fields.get(f)
+        if cur is None:
+            print(f"  MISSING in offset_table.c: .{f} (generated {hx(v)})"); mism += 1
+        elif cur != v:
+            print(f"  MISMATCH .{f}: table={hx(cur)} generated={hx(v)}"); mism += 1
+    gen_remap = {b: n for b, n, _ in out["remap"]}
+    cur_remap = dict(remap)
+    for b, n in gen_remap.items():
+        if cur_remap.get(b) != n:
+            print(f"  REMAP MISMATCH 0x{b:x}: table={cur_remap.get(b) and hex(cur_remap[b])} generated=0x{n:x}"); mism += 1
+    if mism == 0:
+        print(f"  ✓ all {len(gen)} fields + {len(gen_remap)} remap entries match offset_table.c")
+    return mism
+
+# ----------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("cmd", choices=["resolve", "verify"])
+    ap.add_argument("--binary", default=DEFAULT_BINARY, help="path to the BG3 Mach-O binary")
+    ap.add_argument("--version", help="override detected version label")
+    ap.add_argument("--emit", action="store_true", help="(resolve) print copy-pasteable offset_table.c content")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.binary):
+        sys.exit(f"error: binary not found: {args.binary}\n  pass --binary PATH")
+    manifest = json.load(open(MANIFEST))
+    version = args.version or detect_version(args.binary) or "UNKNOWN"
+
+    print(f"binary : {args.binary}")
+    print(f"version: {version}")
+    print("indexing symbols (nm + c++filt)...")
+    symtab = build_symbol_map(thin_arm64(args.binary))
+    print(f"  {len(symtab)} symbols\n")
+
+    out, issues = resolve(manifest, symtab)
+
+    rank = {"FATAL": 0, "ERROR": 1, "WARN": 2, "INFO": 3}
+    for lvl, msg in sorted(issues, key=lambda i: rank.get(i[0], 9)):
+        print(f"[{lvl}] {msg}")
+    errs = sum(1 for l, _ in issues if l in ("FATAL", "ERROR"))
+    print()
+
+    if args.cmd == "verify":
+        mism = do_verify(out, version)
+        sys.exit(1 if (mism or errs) else 0)
+
+    # resolve
+    nres = len(out["fn"]) + len(out["data"]) + len(out["remap"]) + len(out["exported"])
+    print(f"resolved {nres} addresses; {len(out['struct'])} struct offsets carried (stable).")
+    if args.emit:
+        print("\n" + "=" * 70)
+        print(emit_c(out, version))
+        print("=" * 70)
+    else:
+        print("re-run with --emit to print copy-pasteable offset_table.c content.")
+    sys.exit(1 if errs else 0)
+
+if __name__ == "__main__":
+    main()

--- a/tools/port_offsets.py
+++ b/tools/port_offsets.py
@@ -88,21 +88,39 @@ def hx(v):
 # Resolution
 # ----------------------------------------------------------------------------
 
-def resolve(manifest, symtab):
+def got_slots(thin):
+    """{symbol_mangled: slot_va} from otool -Iv (indirect-symbol table)."""
+    out = {}
+    res = subprocess.run(["otool", "-arch", "arm64", "-Iv", thin],
+                         capture_output=True, text=True)
+    for line in res.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[0].startswith("0x"):
+            out.setdefault(parts[2], int(parts[0], 16))
+    return out
+
+
+def resolve(manifest, symtab, thin):
     """Return a dict of resolved values + a list of (level, message) issues."""
     issues = []
     out = {"fn": {}, "data": {}, "remap": [], "exported": {}, "constants": [], "struct": []}
 
-    # 1. derive the __DATA shift from the anchor
+    # 1. derive component_data_shift from the anchor.
+    # NOTE: the anchor baseline is the 7209685 address (the vintage of the
+    # compiled-in constants), so the result IS component_data_shift for the
+    # target version: 0 on 7209685 itself, -0x8000 on 6995620.
+    # It is used ONLY for TypeId globals (proven-uniform family), never for
+    # the data singletons below — those resolve per-entry.
     anchor = manifest["data_shift_anchor"]
     a_addr, a_note = lookup(symtab, anchor["symbol"])
     if a_addr is None:
         issues.append(("FATAL", f"data_shift anchor '{anchor['symbol']}' not found — "
-                                "cannot derive __DATA shift. Pick another exported anchor."))
+                                "cannot derive component_data_shift. Pick another anchor."))
         return out, issues
     shift = a_addr - int(anchor["baseline"], 16)
     out["data_shift"] = shift
-    issues.append(("INFO", f"__DATA shift derived from anchor: {hx(shift)} "
+    issues.append(("INFO", f"component_data_shift (delta from {manifest.get('constants_vintage','7209685')} "
+                           f"constants): {shift:#x} "
                            f"(anchor {anchor['symbol'].split('(')[0]} {hx(int(anchor['baseline'],16))} -> 0x{a_addr:x})"))
 
     # 2. offset_table functions (symbol)
@@ -115,28 +133,62 @@ def resolve(manifest, symtab):
             if note:
                 issues.append(("WARN", f"offset_table.{e['field']}: {note}"))
 
-    # 3. data singletons (data_shift)
+    # 3. data singletons — per-entry method; NO uniform-shift assumption
+    # (global_switches_ptr moved -0x24000 while its neighbors moved +0x8000).
+    gots = None
     for e in manifest["data_singletons"]:
-        out["data"][e["field"]] = int(e["baseline"], 16) + shift
+        method = e.get("method", "symbol")
+        if method == "symbol":
+            addr, note = lookup(symtab, e["symbol"])
+            if addr is None:
+                issues.append(("ERROR", f"offset_table.{e['field']}: symbol not found "
+                                        f"({e.get('symbol','?')[:60]})"))
+                continue
+            out["data"][e["field"]] = addr - GHIDRA_BASE
+            if note:
+                issues.append(("WARN", f"offset_table.{e['field']}: {note}"))
+        elif method == "got":
+            if gots is None:
+                gots = got_slots(thin)
+            # match by mangled name fragment of the target symbol
+            # (exclude __ZGV* guard variables — same suffix, wrong slot)
+            frag = "m_StateE"
+            cands = {s: va for s, va in gots.items()
+                     if "ImmutableDataHeadmaster" in s and s.endswith(frag)
+                     and not s.startswith("__ZGV")}
+            if len(cands) == 1:
+                out["data"][e["field"]] = next(iter(cands.values())) - GHIDRA_BASE
+            else:
+                issues.append(("ERROR", f"offset_table.{e['field']}: __got slot for "
+                                        f"'{e['symbol']}' not uniquely found "
+                                        f"({len(cands)} candidates) — resolve via otool -Iv manually"))
+        elif method == "disasm":
+            issues.append(("WARN", f"offset_table.{e['field']}: MANUAL — anonymous slot, "
+                                   f"no symbol. {e.get('note','')}"))
+        else:
+            issues.append(("ERROR", f"offset_table.{e['field']}: unknown method '{method}'"))
 
-    # 4. exported data (symbol; cross-check against data_shift where applicable)
+    # 4. exported data (symbol)
     for e in manifest["exported_data"]:
         addr, note = lookup(symtab, e["symbol"])
         if addr is None:
             issues.append(("ERROR", f"exported_data {e['name']}: symbol not found"))
         else:
             out["exported"][e["name"]] = addr
-            base = e.get("baseline")
-            if base and (addr - int(base, 16)) != shift:
-                issues.append(("WARN", f"exported_data {e['name']}: shift {hx(addr-int(base,16))} "
-                                       f"!= __DATA shift {hx(shift)} (segment may differ)"))
 
-    # 5. remap functions (symbol)
+    # 5. remap functions (symbol). ABI CAUTION: resolving a symbol proves the
+    # ADDRESS, not the SIGNATURE the C wrapper expects — entries flagged
+    # abi_changed emit 0 until a matching wrapper exists.
     for e in manifest["remap_functions"]:
         addr, note = lookup(symtab, e["symbol"])
         if addr is None:
             issues.append(("ERROR", f"remap {e['name']}: symbol not found ({e['symbol'][:60]}...)"))
         else:
+            if e.get("abi_changed"):
+                issues.append(("WARN", f"remap {e['name']}: ABI CHANGED — emitting 0 "
+                                       f"(found at 0x{addr:x}, but the wrapper signature "
+                                       f"does not fit; see manifest _note)"))
+                addr = 0
             out["remap"].append((int(e["baseline"], 16), addr, e["name"]))
             if note:
                 issues.append(("WARN", f"remap {e['name']}: {note}"))
@@ -166,17 +218,20 @@ def emit_c(out, version):
     L.append("    {")
     L.append(f'        .version                 = "{version}",')
     L.append("")
-    L.append("        /* Singleton pointer globals (data_shift = %s) */" % hx(out["data_shift"]))
+    L.append("        /* Singleton pointer globals (per-entry symbol/got resolution) */")
     for field, val in out["data"].items():
         L.append(f"        .{field:<24} = {hx(val)},")
     L.append("")
     L.append("        /* Function offsets (symbol-resolved) */")
     for field, val in out["fn"].items():
         L.append(f"        .{field:<24} = {hx(val)},")
-    L.append(f"        .component_data_shift    = {hx(out['data_shift'])},")
+    shift = out["data_shift"]
+    L.append(f"        .component_data_shift    = {'-' if shift < 0 else ''}{hx(abs(shift))},")
     L.append("    },")
     L.append("")
-    L.append(f"    /* g_fn_remap_<ver> entries for {version}: */")
+    L.append(f"    /* g_fn_remap: {version} column values (row key = 6995620 baseline). */")
+    L.append("    /* NOTE: g_fn_remap is a fixed two-column {6995620, 7209685} table; a  */")
+    L.append("    /* THIRD version needs a schema change (add a column), not new rows.   */")
     for base, new, name in out["remap"]:
         L.append(f"    {{ 0x{base:09x}, 0x{new:09x} }},  // {name}")
     return "\n".join(L)
@@ -192,12 +247,13 @@ def parse_offset_table_c(version):
     # find the struct entry for this version
     m = re.search(r'\.version\s*=\s*"' + re.escape(version) + r'"(.*?)\n\s*\},', txt, re.S)
     if m:
-        for fm in re.finditer(r'\.(\w+)\s*=\s*(0x[0-9a-fA-F]+)', m.group(1)):
-            fields[fm.group(1)] = int(fm.group(2), 16)
+        for fm in re.finditer(r'\.(\w+)\s*=\s*(-?0x[0-9a-fA-F]+|\d+)', m.group(1)):
+            v = fm.group(2)
+            fields[fm.group(1)] = int(v, 16) if "0x" in v else int(v)
     remap = []
-    rm = re.search(r'g_fn_remap_\w+\[\]\s*=\s*\{(.*?)\n\};', txt, re.S)
+    rm = re.search(r'g_fn_remap\[\]\s*=\s*\{(.*?)\n\};', txt, re.S)
     if rm:
-        for pm in re.finditer(r'\{\s*(0x[0-9a-fA-F]+)\s*,\s*(0x[0-9a-fA-F]+)\s*\}', rm.group(1)):
+        for pm in re.finditer(r'\{\s*(0x[0-9a-fA-F]+)\s*,\s*(0x[0-9a-fA-F]+|0)\s*\}', rm.group(1)):
             remap.append((int(pm.group(1), 16), int(pm.group(2), 16)))
     return fields, remap
 
@@ -241,10 +297,11 @@ def main():
     print(f"binary : {args.binary}")
     print(f"version: {version}")
     print("indexing symbols (nm + c++filt)...")
-    symtab = build_symbol_map(thin_arm64(args.binary))
+    thin = thin_arm64(args.binary)
+    symtab = build_symbol_map(thin)
     print(f"  {len(symtab)} symbols\n")
 
-    out, issues = resolve(manifest, symtab)
+    out, issues = resolve(manifest, symtab, thin)
 
     rank = {"FATAL": 0, "ERROR": 1, "WARN": 2, "INFO": 3}
     for lvl, msg in sorted(issues, key=lambda i: rank.get(i[0], 9)):


### PR DESCRIPTION
# Integrate community PRs #91 (offset table) and #93 (Osiris DB + mod runtime)

Reconciles both community pull requests with the current codebase. Neither could merge verbatim — both predated the v0.38.x mod-detection and game-path work, and #93 was written against a pre-offset-table tree — so each was re-based conceptually: the *design* was preserved, the mechanics were adapted to the repo as it stands, and every address-dependent value was routed through the offset-table architecture that #91 itself introduced.

## What landed, and how it was reconciled

### From PR #91 — @mikowals

- **Per-version offset table** (`src/core/offset_table.c/h`): every game-version-dependent address lives in one table keyed by build; unknown builds fail closed (feature disabled, not garbage reads). Cherry-picked with mikowals's authorship (`452fb9f`), then reconciled with the 7209685-vintage constants already verified in this repo (`d16a5dc`).
- **`tools/port_offsets.py`**: semi-automated migration of the table to new game builds, with a `verify` mode wired into the audit suite.
- Every hardcoded address is now validated by `tests/harness/test_offset_audit.py` against `nm`/`otool` on the installed binary — including a new disassembly-based check for the one slot with no symbol (see below).

### From PR #93 — @marcus-sa

Ported in reviewed clusters rather than as one diff, each commit carrying `Ported-from: #93` and co-authorship:

1. **Osiris database access** (`659c753`): marcus-sa's reverse engineering of libOsiris (documented in `ghidra/offsets/OSIRIS_DATABASES.md`) — the name-index walk of `COsiFunctionMan` that discovers databases (invisible to the id-probe enumeration), and the `def → ReteNode → CReteDBase → Facts` resolution chain that lets `Osi.DB_X:Get(...)` read real database tuples with typed filters, Windows-style. His `OsirisInterface` param-defs discovery (types + in/out directions read from the game's own function defs) replaced arity-guessing in Osi dispatch; pure test queries now return integer `0/1` and out-param queries return values or `nil` (Windows parity). His hardcoded image-base arithmetic was replaced with an `osiris_interface_ptr` offset-table field, verified per-version by disassembling `OsirisQuery`'s ADRP+LDR pair.
2. **Mod loading runtime** (`cc89474`, `c528547`): Folder-keyed mod detection with UUID capture, per-mod `_ENV` sandbox (`Mods.<ModTable>` with `__index = _G` fallback and mod-local `_G`/`ModuleUUID`), registry-backed module cache, bare `require()` with dot-path resolution, `Ext.IO` VFS semantics (PAK fallback reads, Script-Extender-dir writes), `Info`/`ModVersion` decoding from `Version64`, and GameStateChanged events carrying `ClientGameState` EnumValues. Reconciled with the v0.38.1 PAK-stem/`se_mod_dirs` detection fallback rather than replacing it — the two compose (modsettings Folder first, PAK-directory resolution when they differ, e.g. MCM).

### Hardening pass (`8c36965`)

Before this PR, the integration was reviewed by four agents (two Codex, two Claude) with adversarial scopes; every confirmed finding was fixed and re-validated: CTuple small-object storage (inline values when capacity < 9), stale-registry re-walk on save load, param-def validation before strict engine dispatch, safe-memory copies of engine strings, `Ext.IO` path containment (no absolute writes, no `..` traversal), PAK entry bounds validation against the real archive size, per-mod loader state cleared after bootstrap, and `ClientGameState`/`ServerGameState` registered in `Ext.Enums` so the EnumValue compare path actually resolves.

## Validation

- Offline: tier-0 55/55, harness pytest 179/179 (includes the new offset-audit disasm check).
- Live (build 4.1.1.7209685): tier-1 109/109; tier-2 61/67 — identical failure set to the pre-integration baseline (known Entity/Level gaps tracked for later waves), both `Parity.Osi` tests green.
- `Osi.DB_Players:Get()` returns the real 4-row party table with correct GUID strings; filtered queries and `DB_PartyMembers` verified live.
- `Ext.Utils.GetGameState() == Ext.Enums.ClientGameState.Running` → `true`.
- MCM compat vet: **working**, bootstrap executed, zero errors (`docs/compat-reports/mod_configuration_menu_1785345864.json`).

## Not yet ported from #93

Two clusters remain and can land on this branch before merge or as follow-ups: the IMGUI event queue rework and the network local-bus changes. The PR #93 thread will be updated with the split.

## Credits

- **@mikowals** — offset-table architecture, build 7209685 offsets, `port_offsets.py` (PR #91). Authored commit on this branch.
- **@marcus-sa** — libOsiris database RE, Facts reader design, param-defs discovery, mod runtime `_ENV`/require/Ext.IO semantics (PR #93). Authored and co-authored commits on this branch.
